### PR TITLE
fix: incremental solving (rip issue #75)

### DIFF
--- a/tests/solver.rs
+++ b/tests/solver.rs
@@ -458,7 +458,6 @@ fn test_resolve_with_nonexisting() {
 
 #[test]
 #[traced_test]
-#[should_panic] // TODO: Should be fixed, https://github.com/prefix-dev/rip/issues/75
 fn test_resolve_with_nested_deps() {
     let provider = BundleBoxProvider::from_packages(&[
         (


### PR DESCRIPTION
The original bug was caused by adding a conflicting `requires` clause, yet failing to detect and handle the conflict. This commit introduces a clearer separation between: adding new clauses, detecting conflicts, and handling said conflicts.

Closes #13 

Closes https://github.com/prefix-dev/rip/issues/75