### PR TITLE
Allow returning "unknown dependencies" in `get_dependencies`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub struct Candidates {
     /// no solution could be found otherwise.
     ///
     /// The same behavior can be achieved by sorting this candidate to the top using the
-    /// [`DependencyProvider::sort_candidates`] function but using this method providers better
+    /// [`DependencyProvider::sort_candidates`] function but using this method provides better
     /// error messages to the user.
     pub favored: Option<SolvableId>,
 
@@ -115,14 +115,25 @@ pub struct Candidates {
 }
 
 /// Holds information about the dependencies of a package.
+pub enum Dependencies {
+    /// The dependencies are known.
+    Known(KnownDependencies),
+    /// The dependencies are unknown, so the parent solvable should be excluded from the solution.
+    ///
+    /// The string provides more information about why the dependencies are unknown (e.g. an error
+    /// message).
+    Unknown(StringId),
+}
+
+/// Holds information about the dependencies of a package when they are known.
 #[derive(Default, Clone, Debug)]
-pub struct Dependencies {
+pub struct KnownDependencies {
     /// Defines which packages should be installed alongside the depending package and the
     /// constraints applied to the package.
     pub requirements: Vec<VersionSetId>,
 
     /// Defines additional constraints on packages that may or may not be part of the solution.
-    /// Different from `requirements` packages in this set are not necessarily included in the
+    /// Different from `requirements`, packages in this set are not necessarily included in the
     /// solution. Only when one or more packages list the package in their `requirements` is the
     /// package also added to the solution.
     ///

--- a/src/solver/clause.rs
+++ b/src/solver/clause.rs
@@ -574,8 +574,13 @@ impl<VS: VersionSet, N: PackageName + Display> Debug for ClauseDebug<'_, VS, N> 
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self.kind {
             Clause::InstallRoot => write!(f, "install root"),
-            Clause::Excluded(_, reason) => {
-                write!(f, "excluded because {}", self.pool.resolve_string(reason))
+            Clause::Excluded(solvable_id, reason) => {
+                write!(
+                    f,
+                    "{} excluded because: {}",
+                    solvable_id.display(self.pool),
+                    self.pool.resolve_string(reason)
+                )
             }
             Clause::Learnt(learnt_id) => write!(f, "learnt clause {learnt_id:?}"),
             Clause::Requires(solvable_id, match_spec_id) => {


### PR DESCRIPTION
Note: this assumes #15 and #16 are merged.

Question: should we make it possible for the provider to tell the reason why the dependencies are unknown? For instance, a string where we can put the contents of [this panic](https://github.com/prefix-dev/rip/blob/25e2344e62804dab039a1c806b7489c3779f3e47/crates/rattler_installs_packages/src/resolve/dependency_provider.rs#L475-L478)

Closes #14 