### PR TITLE
feat: allow cancelling the solving process

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,9 @@ pub use internal::{
 };
 pub use pool::Pool;
 pub use solvable::Solvable;
-pub use solver::{Solver, SolverCache};
+pub use solver::{Solver, SolverCache, UnsolvableOrCancelled};
 use std::{
+    any::Any,
     fmt::{Debug, Display},
     hash::Hash,
 };
@@ -75,6 +76,16 @@ pub trait DependencyProvider<VS: VersionSet, N: PackageName = String>: Sized {
 
     /// Returns the dependencies for the specified solvable.
     fn get_dependencies(&self, solvable: SolvableId) -> Dependencies;
+
+    /// Whether the solver should stop the dependency resolution algorithm.
+    ///
+    /// This method gets called at the beginning of each unit propagation round and before
+    /// potentially blocking operations (like [Self::get_dependencies] and [Self::get_candidates]).
+    /// If it returns `Some(...)`, the solver will stop and return
+    /// [UnsolvableOrCancelled::Cancelled].
+    fn should_cancel_with_value(&self) -> Option<Box<dyn Any>> {
+        None
+    }
 }
 
 /// A list of candidate solvables for a specific package. This is returned from

--- a/src/problem.rs
+++ b/src/problem.rs
@@ -65,7 +65,9 @@ impl Problem {
                 &Clause::Requires(package_id, version_set_id) => {
                     let package_node = Self::add_node(&mut graph, &mut nodes, package_id);
 
-                    let candidates = solver.cache.get_or_cache_sorted_candidates(version_set_id);
+                    let candidates = solver.cache.get_or_cache_sorted_candidates(version_set_id).unwrap_or_else(|_| {
+                        unreachable!("The version set was used in the solver, so it must have been cached. Therefore cancellation is impossible here and we cannot get an `Err(...)`")
+                    });
                     if candidates.is_empty() {
                         tracing::info!(
                             "{package_id:?} requires {version_set_id:?}, which has no candidates"

--- a/tests/snapshots/solver__resolve_and_cancel.snap
+++ b/tests/snapshots/solver__resolve_and_cancel.snap
@@ -1,0 +1,5 @@
+---
+source: tests/solver.rs
+expression: error
+---
+cancelled!


### PR DESCRIPTION
Introduces a `should_cancel_with_value` method in `DependencyProvider`,
that returns an `Option<Box<dyn Any>>`. This method is called at the
beginning of each unit propagation round and before potentially blocking
operations (like [Self::get_dependencies] and [Self::get_candidates]).

If `should_cancel_with_value` returns `Some(...)`,
propagation is interrupted and the solver returns
`Err(UnsolvableOrCancelled::Cancelled(...))`, bubbling up the value to
the library user (this way you can handle any additional details
surrounding the cancellation outside of the solver).

Closes #8.

## Remarks

- `SolverCache::provider` is now `pub(crate)`. Is that all right?
- The current design requires implementors of `DependencyProvider` to use interior mutability to track cancellation. I think that's reasonable, because otherwise we would need to take `&mut self` in all of `DependencyProvider` methods, but I'm mentioning it here in case anyone has a different opinion.