### PR TITLE
fix: merge similar excluded messages when unsat

### DIFF
--- a/tests/snapshots/solver__merge_excluded.snap
+++ b/tests/snapshots/solver__merge_excluded.snap
@@ -4,6 +4,5 @@ expression: "solve_snapshot(provider, &[\"a\"])"
 ---
 The following packages are incompatible
 |-- a * cannot be installed because there are no viable options:
-    |-- a 2 is excluded because it is externally excluded
-    |-- a 1 is excluded because it is externally excluded
+    |-- a 1 | 2 is excluded because it is externally excluded
 


### PR DESCRIPTION
The previous implementation represented `excluded` as an incoming conflict, thereby preventing the merging algorithm from grouping excludes together. This PR represents `excluded` as an outgoing conflict, which allows the merging algorithm to do its job. See the modified snapshot for details.

This addresses one of the issues in #9.

Below are some pictures of the internal graph, in case you are curious.

## Before

![image](https://github.com/mamba-org/resolvo/assets/5196584/d2c4cce8-d2bd-4d1e-9325-14a3474dd2d0)

## After

![image](https://github.com/mamba-org/resolvo/assets/5196584/e0788f68-feaf-4256-99d1-a9d50324c355)