### PR TITLE
fix: merge nodes more aggressively when unsat

### DIFF
--- a/src/problem.rs
+++ b/src/problem.rs
@@ -248,7 +248,6 @@ pub enum ConflictCause {
 /// - They all have the same name
 /// - They all have the same predecessor nodes
 /// - They all have the same successor nodes
-/// - None of them have incoming conflicting edges
 pub(crate) struct MergedProblemNode {
     pub ids: Vec<SolvableId>,
 }
@@ -369,14 +368,6 @@ impl ProblemGraph {
                     }
                 }
             };
-
-            if graph
-                .edges_directed(node_id, Direction::Incoming)
-                .any(|e| matches!(e.weight(), ProblemEdge::Conflict(..)))
-            {
-                // Nodes that are the target of a conflict should never be merged
-                continue;
-            }
 
             let predecessors: Vec<_> = graph
                 .edges_directed(node_id, Direction::Incoming)

--- a/tests/snapshots/solver__merge_installable.snap
+++ b/tests/snapshots/solver__merge_installable.snap
@@ -1,0 +1,10 @@
+---
+source: tests/solver.rs
+expression: "solve_snapshot(provider, &[\"a 0..3\", \"a 3..5\"])"
+---
+The following packages are incompatible
+|-- a >=3, <5 can be installed with any of the following options:
+    |-- a 3 | 4
+|-- a >=0, <3 cannot be installed because there are no viable options:
+    |-- a 1 | 2, which conflicts with the versions reported above.
+

--- a/tests/snapshots/solver__unsat_constrains_2.snap
+++ b/tests/snapshots/solver__unsat_constrains_2.snap
@@ -1,21 +1,10 @@
 ---
 source: tests/solver.rs
-assertion_line: 703
 expression: error
 ---
 The following packages are incompatible
 |-- a * cannot be installed because there are no viable options:
-    |-- a 2 would require
-        |-- b *, which cannot be installed because there are no viable options:
-            |-- b 2 would require
-                |-- c >=2, <3, which cannot be installed because there are no viable options:
-                    |-- c 2 would constrain
-                        |-- a >=3, <4 , which conflicts with any installable versions previously reported
-            |-- b 1 would require
-                |-- c >=1, <2, which cannot be installed because there are no viable options:
-                    |-- c 1 would constrain
-                        |-- a >=3, <4 , which conflicts with any installable versions previously reported
-    |-- a 1 would require
+    |-- a 1 | 2 would require
         |-- b *, which cannot be installed because there are no viable options:
             |-- b 2 would require
                 |-- c >=2, <3, which cannot be installed because there are no viable options:

--- a/tests/solver.rs
+++ b/tests/solver.rs
@@ -913,6 +913,17 @@ fn test_merge_excluded() {
 }
 
 #[test]
+fn test_merge_installable() {
+    let provider = BundleBoxProvider::from_packages(&[
+        ("a", 1, vec![]),
+        ("a", 2, vec![]),
+        ("a", 3, vec![]),
+        ("a", 4, vec![]),
+    ]);
+    insta::assert_snapshot!(solve_snapshot(provider, &["a 0..3", "a 3..5"]));
+}
+
+#[test]
 fn test_root_excluded() {
     let mut provider = BundleBoxProvider::from_packages(&[("a", 1, vec![])]);
     provider.exclude("a", 1, "it is externally excluded");


### PR DESCRIPTION
Until now the merging algorithm refused to merge nodes with incoming conflicting edges. I don't remember why that was necessary, and can't think of a reason now (if anyone does, please chime in!)... This PR removes that limitation because it improves error messages some more (see the new and updated snapshots).

As an example, consider the difference in output for `rip "requests>2.2" "requests<2.1"` (taken from [this issue](https://github.com/prefix-dev/rip/issues/26)). You can also have a look at the updated insta snapshots.

This addresses one of the issues raised in #9, leaving the "deduce version ranges" part for a future PR.

## Before

```
 × Could not solve for requested requirements
  ╰─▶ The following packages are incompatible
      |-- requests <2.1 can be installed with any of the following options:
          |-- requests 2.0.1
          |-- requests 2.0.0
          |-- requests 1.2.3
          |-- requests 1.2.2
          |-- requests 1.2.1
          |-- requests 1.2.0
          |-- requests 1.1.0
          |-- requests 1.0.4
          |-- requests 1.0.3
          |-- requests 1.0.2
          |-- requests 1.0.1
          |-- requests 1.0.0
          |-- requests 0.14.2
          |-- requests 0.14.1
          |-- requests 0.14.0
          |-- requests 0.13.9
          |-- requests 0.13.8
          |-- requests 0.13.7
          |-- requests 0.13.6
          |-- requests 0.13.5
          |-- requests 0.13.4
          |-- requests 0.13.3
          |-- requests 0.13.2
          |-- requests 0.13.1
          |-- requests 0.13.0
          |-- requests 0.12.1
          |-- requests 0.12.0
          |-- requests 0.11.2
          |-- requests 0.11.1
          |-- requests 0.10.8
          |-- requests 0.10.7
          |-- requests 0.10.6
          |-- requests 0.10.4
          |-- requests 0.10.3
          |-- requests 0.10.2
          |-- requests 0.10.1
          |-- requests 0.10.0
          |-- requests 0.9.3
          |-- requests 0.9.2
          |-- requests 0.9.1
          |-- requests 0.9.0
          |-- requests 0.8.9
          |-- requests 0.8.8
          |-- requests 0.8.7
          |-- requests 0.8.6
          |-- requests 0.8.5
          |-- requests 0.8.4
          |-- requests 0.8.3
          |-- requests 0.8.2
          |-- requests 0.8.1
          |-- requests 0.8.0
          |-- requests 0.7.6
          |-- requests 0.7.5
          |-- requests 0.7.4
          |-- requests 0.7.3
          |-- requests 0.7.2
          |-- requests 0.7.1
          |-- requests 0.7.0
          |-- requests 0.6.6
          |-- requests 0.6.5
          |-- requests 0.6.4
          |-- requests 0.6.3
          |-- requests 0.6.2
          |-- requests 0.6.1
          |-- requests 0.6.0
          |-- requests 0.5.1
          |-- requests 0.5.0
          |-- requests 0.4.1
          |-- requests 0.4.0
          |-- requests 0.3.4
          |-- requests 0.3.3
          |-- requests 0.3.2
          |-- requests 0.3.1
          |-- requests 0.3.0
          |-- requests 0.2.4
          |-- requests 0.2.3
          |-- requests 0.2.2
          |-- requests 0.2.1
          |-- requests 0.2.0
      |-- requests >2.2 cannot be installed because there are no viable options:
          |-- requests 2.2.1 | 2.3.0 | 2.4.0 | 2.4.1 | 2.4.2 | 2.4.3 | 2.5.0 | 2.5.1 | 2.5.2 | 2.5.3 | 2.6.0 | 2.6.1 | 2.6.2 | 2.7.0 | 2.8.0 | 2.8.1 | 2.9.0 | 2.9.1 | 2.9.2 | 2.10.0 | 2.11.0 |     
      2.11.1 | 2.12.0 | 2.12.1 | 2.12.2 | 2.12.3 | 2.12.4 | 2.12.5 | 2.13.0 | 2.14.0 | 2.14.1 | 2.14.2 | 2.15.1 | 2.16.0 | 2.16.1 | 2.16.2 | 2.16.3 | 2.16.4 | 2.16.5 | 2.17.0 | 2.17.1 | 2.17.2 |   
      2.17.3 | 2.18.0 | 2.18.1 | 2.18.2 | 2.18.3 | 2.18.4 | 2.19.0 | 2.19.1 | 2.20.0 | 2.20.1 | 2.21.0 | 2.22.0 | 2.23.0 | 2.24.0 | 2.25.0 | 2.25.1 | 2.26.0 | 2.27.0 | 2.27.1 | 2.28.0 | 2.28.1 |   
      2.28.2 | 2.29.0 | 2.30.0 | 2.31.0, which conflicts with the versions reported above.
```

## After

```
  × Could not solve for requested requirements
  ╰─▶ The following packages are incompatible
      |-- requests <2.1 can be installed with any of the following options:
          |-- requests 0.2.0 | 0.2.1 | 0.2.2 | 0.2.3 | 0.2.4 | 0.3.0 | 0.3.1 | 0.3.2 | 0.3.3 | 0.3.4 | 0.4.0 | 0.4.1 | 0.5.0 | 0.5.1 | 0.6.0 | 0.6.1 | 0.6.2 | 0.6.3 | 0.6.4 | 0.6.5 | 0.6.6 |       
      0.7.0 | 0.7.1 | 0.7.2 | 0.7.3 | 0.7.4 | 0.7.5 | 0.7.6 | 0.8.0 | 0.8.1 | 0.8.2 | 0.8.3 | 0.8.4 | 0.8.5 | 0.8.6 | 0.8.7 | 0.8.8 | 0.8.9 | 0.9.0 | 0.9.1 | 0.9.2 | 0.9.3 | 0.10.0 | 0.10.1 |      
      0.10.2 | 0.10.3 | 0.10.4 | 0.10.6 | 0.10.7 | 0.10.8 | 0.11.1 | 0.11.2 | 0.12.0 | 0.12.1 | 0.13.0 | 0.13.1 | 0.13.2 | 0.13.3 | 0.13.4 | 0.13.5 | 0.13.6 | 0.13.7 | 0.13.8 | 0.13.9 | 0.14.0 |   
      0.14.1 | 0.14.2 | 1.0.0 | 1.0.1 | 1.0.2 | 1.0.3 | 1.0.4 | 1.1.0 | 1.2.0 | 1.2.1 | 1.2.2 | 1.2.3 | 2.0.0 | 2.0.1
      |-- requests >2.2 cannot be installed because there are no viable options:
          |-- requests 2.2.1 | 2.3.0 | 2.4.0 | 2.4.1 | 2.4.2 | 2.4.3 | 2.5.0 | 2.5.1 | 2.5.2 | 2.5.3 | 2.6.0 | 2.6.1 | 2.6.2 | 2.7.0 | 2.8.0 | 2.8.1 | 2.9.0 | 2.9.1 | 2.9.2 | 2.10.0 | 2.11.0 |     
      2.11.1 | 2.12.0 | 2.12.1 | 2.12.2 | 2.12.3 | 2.12.4 | 2.12.5 | 2.13.0 | 2.14.0 | 2.14.1 | 2.14.2 | 2.15.1 | 2.16.0 | 2.16.1 | 2.16.2 | 2.16.3 | 2.16.4 | 2.16.5 | 2.17.0 | 2.17.1 | 2.17.2 |   
      2.17.3 | 2.18.0 | 2.18.1 | 2.18.2 | 2.18.3 | 2.18.4 | 2.19.0 | 2.19.1 | 2.20.0 | 2.20.1 | 2.21.0 | 2.22.0 | 2.23.0 | 2.24.0 | 2.25.0 | 2.25.1 | 2.26.0 | 2.27.0 | 2.27.1 | 2.28.0 | 2.28.1 |   
      2.28.2 | 2.29.0 | 2.30.0 | 2.31.0, which conflicts with the versions reported above.
```