### PR TITLE
feat: improved indentation in error messages

### DIFF
--- a/tests/snapshots/solver__excluded.snap
+++ b/tests/snapshots/solver__excluded.snap
@@ -3,11 +3,11 @@ source: tests/solver.rs
 expression: "solve_snapshot(provider, &[\"a\"])"
 ---
 The following packages are incompatible
-|-- a * cannot be installed because there are no viable options:
-    |-- a 2 would require
-        |-- b *, which cannot be installed because there are no viable options:
-            |-- b 1 is excluded because it is externally excluded
-    |-- a 1 would require
-        |-- c *, which cannot be installed because there are no viable options:
-            |-- c 1 is excluded because it is externally excluded
+└─ a * cannot be installed because there are no viable options:
+   ├─ a 2 would require
+   │  └─ b *, which cannot be installed because there are no viable options:
+   │     └─ b 1 is excluded because it is externally excluded
+   └─ a 1 would require
+      └─ c *, which cannot be installed because there are no viable options:
+         └─ c 1 is excluded because it is externally excluded
 

--- a/tests/snapshots/solver__merge_excluded.snap
+++ b/tests/snapshots/solver__merge_excluded.snap
@@ -3,6 +3,6 @@ source: tests/solver.rs
 expression: "solve_snapshot(provider, &[\"a\"])"
 ---
 The following packages are incompatible
-|-- a * cannot be installed because there are no viable options:
-    |-- a 1 | 2 is excluded because it is externally excluded
+└─ a * cannot be installed because there are no viable options:
+   └─ a 1 | 2 is excluded because it is externally excluded
 

--- a/tests/snapshots/solver__merge_installable.snap
+++ b/tests/snapshots/solver__merge_installable.snap
@@ -3,8 +3,8 @@ source: tests/solver.rs
 expression: "solve_snapshot(provider, &[\"a 0..3\", \"a 3..5\"])"
 ---
 The following packages are incompatible
-|-- a >=3, <5 can be installed with any of the following options:
-    |-- a 3 | 4
-|-- a >=0, <3 cannot be installed because there are no viable options:
-    |-- a 1 | 2, which conflicts with the versions reported above.
+├─ a >=3, <5 can be installed with any of the following options:
+│  └─ a 3 | 4
+└─ a >=0, <3 cannot be installed because there are no viable options:
+   └─ a 1 | 2, which conflicts with the versions reported above.
 

--- a/tests/snapshots/solver__merge_installable_non_continuous_range.snap
+++ b/tests/snapshots/solver__merge_installable_non_continuous_range.snap
@@ -1,0 +1,10 @@
+---
+source: tests/solver.rs
+expression: "solve_snapshot(provider, &[\"a 1\", \"a 2..20\"])"
+---
+The following packages are incompatible
+├─ a >=2, <20 can be installed with any of the following options:
+│  └─ a 19 | >=16, <=17 | >=9, <=14 | >=2, <=7
+└─ a >=1, <2 cannot be installed because there are no viable options:
+   └─ a 1, which conflicts with the versions reported above.
+

--- a/tests/snapshots/solver__root_excluded.snap
+++ b/tests/snapshots/solver__root_excluded.snap
@@ -3,6 +3,6 @@ source: tests/solver.rs
 expression: "solve_snapshot(provider, &[\"a\"])"
 ---
 The following packages are incompatible
-|-- a * cannot be installed because there are no viable options:
-    |-- a 1 is excluded because it is externally excluded
+└─ a * cannot be installed because there are no viable options:
+   └─ a 1 is excluded because it is externally excluded
 

--- a/tests/snapshots/solver__unsat_after_backtracking.snap
+++ b/tests/snapshots/solver__unsat_after_backtracking.snap
@@ -1,15 +1,14 @@
 ---
 source: tests/solver.rs
-assertion_line: 605
 expression: error
 ---
 The following packages are incompatible
-|-- b * can be installed with any of the following options:
-    |-- b 6 | 7 would require
-        |-- d >=1, <2, which can be installed with any of the following options:
-            |-- d 1
-|-- c * cannot be installed because there are no viable options:
-    |-- c 1 | 2 would require
-        |-- d >=2, <3, which cannot be installed because there are no viable options:
-            |-- d 2, which conflicts with the versions reported above.
+├─ b * can be installed with any of the following options:
+│  └─ b 6 | 7 would require
+│     └─ d >=1, <2, which can be installed with any of the following options:
+│        └─ d 1
+└─ c * cannot be installed because there are no viable options:
+   └─ c 1 | 2 would require
+      └─ d >=2, <3, which cannot be installed because there are no viable options:
+         └─ d 2, which conflicts with the versions reported above.
 

--- a/tests/snapshots/solver__unsat_applies_graph_compression.snap
+++ b/tests/snapshots/solver__unsat_applies_graph_compression.snap
@@ -1,15 +1,14 @@
 ---
 source: tests/solver.rs
-assertion_line: 671
 expression: error
 ---
 The following packages are incompatible
-|-- a * can be installed with any of the following options:
-    |-- a 9 | 10 would require
-        |-- b *, which can be installed with any of the following options:
-            |-- b 42 | 100 would require
-                |-- c >=0, <100, which can be installed with any of the following options:
-                    |-- c 99
-|-- c >=101, <104 cannot be installed because there are no viable options:
-    |-- c 101 | 103, which conflicts with the versions reported above.
+├─ a * can be installed with any of the following options:
+│  └─ a 9 | 10 would require
+│     └─ b *, which can be installed with any of the following options:
+│        └─ b 42 | 100 would require
+│           └─ c >=0, <100, which can be installed with any of the following options:
+│              └─ c 99
+└─ c >=101, <104 cannot be installed because there are no viable options:
+   └─ c 101 | 103, which conflicts with the versions reported above.
 

--- a/tests/snapshots/solver__unsat_bluesky_conflict.snap
+++ b/tests/snapshots/solver__unsat_bluesky_conflict.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/solver.rs
-assertion_line: 638
 expression: error
 ---
 The following packages are incompatible
-|-- bluesky-widgets >=0, <100 can be installed with any of the following options:
-    |-- bluesky-widgets 42 would require
-        |-- suitcase-utils >=0, <54, which can be installed with any of the following options:
-            |-- suitcase-utils 53
-|-- suitcase-utils >=54, <100 cannot be installed because there are no viable options:
-    |-- suitcase-utils 54, which conflicts with the versions reported above.
+├─ bluesky-widgets >=0, <100 can be installed with any of the following options:
+│  └─ bluesky-widgets 42 would require
+│     └─ suitcase-utils >=0, <54, which can be installed with any of the following options:
+│        └─ suitcase-utils 53
+└─ suitcase-utils >=54, <100 cannot be installed because there are no viable options:
+   └─ suitcase-utils 54, which conflicts with the versions reported above.
 

--- a/tests/snapshots/solver__unsat_constrains.snap
+++ b/tests/snapshots/solver__unsat_constrains.snap
@@ -1,14 +1,13 @@
 ---
 source: tests/solver.rs
-assertion_line: 687
 expression: error
 ---
 The following packages are incompatible
-|-- a * can be installed with any of the following options:
-    |-- a 9 | 10 would require
-        |-- b >=50, <100, which can be installed with any of the following options:
-            |-- b 50
-|-- c * cannot be installed because there are no viable options:
-    |-- c 8 | 10 would constrain
-        |-- b >=0, <50 , which conflicts with any installable versions previously reported
+├─ a * can be installed with any of the following options:
+│  └─ a 9 | 10 would require
+│     └─ b >=50, <100, which can be installed with any of the following options:
+│        └─ b 50
+└─ c * cannot be installed because there are no viable options:
+   └─ c 8 | 10 would constrain
+      └─ b >=0, <50 , which conflicts with any installable versions previously reported
 

--- a/tests/snapshots/solver__unsat_constrains_2.snap
+++ b/tests/snapshots/solver__unsat_constrains_2.snap
@@ -3,15 +3,15 @@ source: tests/solver.rs
 expression: error
 ---
 The following packages are incompatible
-|-- a * cannot be installed because there are no viable options:
-    |-- a 1 | 2 would require
-        |-- b *, which cannot be installed because there are no viable options:
-            |-- b 2 would require
-                |-- c >=2, <3, which cannot be installed because there are no viable options:
-                    |-- c 2 would constrain
-                        |-- a >=3, <4 , which conflicts with any installable versions previously reported
-            |-- b 1 would require
-                |-- c >=1, <2, which cannot be installed because there are no viable options:
-                    |-- c 1 would constrain
-                        |-- a >=3, <4 , which conflicts with any installable versions previously reported
+└─ a * cannot be installed because there are no viable options:
+   └─ a 1 | 2 would require
+      └─ b *, which cannot be installed because there are no viable options:
+         ├─ b 2 would require
+         │  └─ c >=2, <3, which cannot be installed because there are no viable options:
+         │     └─ c 2 would constrain
+         │        └─ a >=3, <4 , which conflicts with any installable versions previously reported
+         └─ b 1 would require
+            └─ c >=1, <2, which cannot be installed because there are no viable options:
+               └─ c 1 would constrain
+                  └─ a >=3, <4 , which conflicts with any installable versions previously reported
 

--- a/tests/snapshots/solver__unsat_incompatible_root_requirements.snap
+++ b/tests/snapshots/solver__unsat_incompatible_root_requirements.snap
@@ -1,11 +1,10 @@
 ---
 source: tests/solver.rs
-assertion_line: 612
 expression: error
 ---
 The following packages are incompatible
-|-- a >=5, <10 can be installed with any of the following options:
-    |-- a 5
-|-- a >=0, <4 cannot be installed because there are no viable options:
-    |-- a 2, which conflicts with the versions reported above.
+├─ a >=5, <10 can be installed with any of the following options:
+│  └─ a 5
+└─ a >=0, <4 cannot be installed because there are no viable options:
+   └─ a 2, which conflicts with the versions reported above.
 

--- a/tests/snapshots/solver__unsat_locked_and_excluded.snap
+++ b/tests/snapshots/solver__unsat_locked_and_excluded.snap
@@ -1,12 +1,11 @@
 ---
 source: tests/solver.rs
-assertion_line: 557
-expression: error
+expression: "solve_snapshot(provider, &[\"asdf\"])"
 ---
 The following packages are incompatible
-|-- asdf * can be installed with any of the following options:
-    |-- asdf 1 would require
-        |-- c >=2, <3, which can be installed with any of the following options:
-            |-- c 2
-|-- c 1 is locked, but another version is required as reported above
+└─ asdf * can be installed with any of the following options:
+   └─ asdf 1 would require
+      └─ c >=2, <3, which can be installed with any of the following options:
+         └─ c 2
+└─ c 1 is locked, but another version is required as reported above
 

--- a/tests/snapshots/solver__unsat_no_candidates_for_child_1.snap
+++ b/tests/snapshots/solver__unsat_no_candidates_for_child_1.snap
@@ -1,9 +1,8 @@
 ---
 source: tests/solver.rs
-assertion_line: 565
 expression: error
 ---
 asdf * cannot be installed because there are no viable options:
-|-- asdf 1 would require
-    |-- c >=2, <3, for which no candidates were found.
+└─ asdf 1 would require
+   └─ c >=2, <3, for which no candidates were found.
 

--- a/tests/snapshots/solver__unsat_no_candidates_for_child_2.snap
+++ b/tests/snapshots/solver__unsat_no_candidates_for_child_2.snap
@@ -1,9 +1,8 @@
 ---
 source: tests/solver.rs
-assertion_line: 573
 expression: error
 ---
 a >=0, <1000 cannot be installed because there are no viable options:
-|-- a 41 would require
-    |-- B >=0, <20, for which no candidates were found.
+└─ a 41 would require
+   └─ B >=0, <20, for which no candidates were found.
 

--- a/tests/snapshots/solver__unsat_pubgrub_article.snap
+++ b/tests/snapshots/solver__unsat_pubgrub_article.snap
@@ -1,17 +1,16 @@
 ---
 source: tests/solver.rs
-assertion_line: 655
 expression: error
 ---
 The following packages are incompatible
-|-- menu * can be installed with any of the following options:
-    |-- menu 10 would require
-        |-- dropdown >=1, <2, which can be installed with any of the following options:
-            |-- dropdown 1 would require
-                |-- intl >=3, <4, which can be installed with any of the following options:
-                    |-- intl 3
-|-- icons >=1, <2 can be installed with any of the following options:
-    |-- icons 1
-|-- intl >=5, <6 cannot be installed because there are no viable options:
-    |-- intl 5, which conflicts with the versions reported above.
+├─ menu * can be installed with any of the following options:
+│  └─ menu 10 would require
+│     └─ dropdown >=1, <2, which can be installed with any of the following options:
+│        └─ dropdown 1 would require
+│           └─ intl >=3, <4, which can be installed with any of the following options:
+│              └─ intl 3
+├─ icons >=1, <2 can be installed with any of the following options:
+│  └─ icons 1
+└─ intl >=5, <6 cannot be installed because there are no viable options:
+   └─ intl 5, which conflicts with the versions reported above.
 


### PR DESCRIPTION
I extracted the new indentation code from #28 

**Old**
```
The following packages are incompatible
|-- a * cannot be installed because there are no viable options:
    |-- a 2 would require
        |-- b *, which cannot be installed because there are no viable options:
            |-- b 1 is excluded because it is externally excluded
    |-- a 1 would require
        |-- c *, which cannot be installed because there are no viable options:
            |-- c 1 is excluded because it is externally excluded
```

**New**
```
The following packages are incompatible
└─ a * cannot be installed because there are no viable options:
   ├─ a 2 would require
   │  └─ b *, which cannot be installed because there are no viable options:
   │     └─ b 1 is excluded because it is externally excluded
   └─ a 1 would require
      └─ c *, which cannot be installed because there are no viable options:
         └─ c 1 is excluded because it is externally excluded
```