### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.1](https://github.com/mamba-org/resolvo/compare/v0.4.0...v0.4.1) - 2024-05-22
+
+### Added
+- add release-plz ([#32](https://github.com/mamba-org/resolvo/pull/32))
+
+### Fixed
+- relax ord constraint ([#31](https://github.com/mamba-org/resolvo/pull/31))
+
+### Other
+- dependencies ([#33](https://github.com/mamba-org/resolvo/pull/33))
+- add projects using resolvo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resolvo"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Adolfo Ochagavía <github@adolfo.ochagavia.nl>", "Bas Zalmstra <zalmstra.bas@gmail.com>", "Tim de Jager <tdejager89@gmail.com>"]
 description = "Fast package resolver written in Rust (CDCL based SAT solving)"
 keywords = ["dependency", "solver", "version"]


### PR DESCRIPTION
## 🤖 New release
* `resolvo`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/mamba-org/resolvo/compare/v0.4.0...v0.4.1) - 2024-05-22

### Added
- add release-plz ([#32](https://github.com/mamba-org/resolvo/pull/32))

### Fixed
- relax ord constraint ([#31](https://github.com/mamba-org/resolvo/pull/31))

### Other
- dependencies ([#33](https://github.com/mamba-org/resolvo/pull/33))
- add projects using resolvo
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).