### PR TITLE
refactor: reduce memory usage

### DIFF
--- a/src/internal/arena.rs
+++ b/src/internal/arena.rs
@@ -107,9 +107,9 @@ impl<TId: ArenaId, TValue> Arena<TId, TValue> {
     pub fn get_two_mut(&mut self, a: TId, b: TId) -> (&mut TValue, &mut TValue) {
         let a_index = a.to_usize();
         let b_index = b.to_usize();
-        assert!(a_index < self.len());
-        assert!(b_index < self.len());
-        assert_ne!(a_index, b_index);
+        debug_assert!(a_index < self.len());
+        debug_assert!(b_index < self.len());
+        debug_assert_ne!(a_index, b_index);
         let (a_chunk, a_offset) = Self::chunk_and_offset(a_index);
         let (b_chunk, b_offset) = Self::chunk_and_offset(b_index);
         // SAFE: because we check that the indices are less than the length and that both indices do
@@ -133,7 +133,7 @@ impl<TId: ArenaId, TValue> Index<TId> for Arena<TId, TValue> {
 
     fn index(&self, index: TId) -> &Self::Output {
         let index = index.to_usize();
-        assert!(index < self.len());
+        debug_assert!(index < self.len());
         let (chunk, offset) = Self::chunk_and_offset(index);
         unsafe {
             let vec = self.chunks.get();
@@ -145,7 +145,7 @@ impl<TId: ArenaId, TValue> Index<TId> for Arena<TId, TValue> {
 impl<TId: ArenaId, TValue> IndexMut<TId> for Arena<TId, TValue> {
     fn index_mut(&mut self, index: TId) -> &mut Self::Output {
         let index = index.to_usize();
-        assert!(index < self.len());
+        debug_assert!(index < self.len());
         let (chunk, offset) = Self::chunk_and_offset(index);
         // SAFE: because we check that the index is less than the length
         unsafe {
@@ -161,6 +161,16 @@ impl<TId: ArenaId, TValue> IndexMut<TId> for Arena<TId, TValue> {
 pub trait ArenaId {
     fn from_usize(x: usize) -> Self;
     fn to_usize(self) -> usize;
+}
+
+impl ArenaId for u32 {
+    fn from_usize(x: usize) -> Self {
+        x as u32
+    }
+
+    fn to_usize(self) -> usize {
+        self as _
+    }
 }
 
 /// An iterator over the elements of an [`Arena`].

--- a/src/internal/id.rs
+++ b/src/internal/id.rs
@@ -95,37 +95,6 @@ impl From<SolvableId> for u32 {
     }
 }
 
-#[repr(transparent)]
-#[derive(Copy, Clone, PartialOrd, Ord, Eq, PartialEq, Debug, Hash)]
-pub(crate) struct ClauseId(u32);
-
-impl ClauseId {
-    /// There is a guarentee that ClauseId(0) will always be "Clause::InstallRoot". This assumption
-    /// is verified by the solver.
-    pub(crate) fn install_root() -> Self {
-        Self(0)
-    }
-
-    pub(crate) fn is_null(self) -> bool {
-        self.0 == u32::MAX
-    }
-
-    pub(crate) fn null() -> ClauseId {
-        ClauseId(u32::MAX)
-    }
-}
-
-impl ArenaId for ClauseId {
-    fn from_usize(x: usize) -> Self {
-        assert!(x < u32::MAX as usize, "clause id too big");
-        Self(x as u32)
-    }
-
-    fn to_usize(self) -> usize {
-        self.0 as usize
-    }
-}
-
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct LearntClauseId(u32);
 

--- a/src/problem.rs
+++ b/src/problem.rs
@@ -11,15 +11,19 @@ use petgraph::graph::{DiGraph, EdgeIndex, EdgeReference, NodeIndex};
 use petgraph::visit::{Bfs, DfsPostOrder, EdgeRef};
 use petgraph::Direction;
 
-use crate::solver::clause::{
-    ConstrainsClause, ExcludeClause, ForbidMultipleInstancesClause, LockClause, RequiresClause,
-};
 use crate::{
-    internal::id::{ClauseId, SolvableId, StringId, VersionSetId},
+    solver::clause::{
+        ClauseId, ConstrainsClause, ExcludeClause, ForbidMultipleInstancesClause, LockClause,
+        RequiresClause,
+    },
+    internal::id::{SolvableId, StringId, VersionSetId},
     pool::Pool,
     runtime::AsyncRuntime,
     solver::{clause::Clause, Solver},
-    DependencyProvider, PackageName, SolvableDisplay, VersionSet,
+    DependencyProvider,
+    PackageName,
+    SolvableDisplay,
+    VersionSet
 };
 
 /// Represents the cause of the solver being unable to find a solution
@@ -55,7 +59,7 @@ impl Problem {
         let unresolved_node = graph.add_node(ProblemNode::UnresolvedDependency);
 
         for &clause_id in &self.clauses {
-            let clause = solver.clauses.borrow().clause(clause_id);
+            let clause = solver.clauses.borrow().clauses.get(clause_id);
             match clause {
                 Clause::InstallRoot => (),
                 Clause::Excluded(ExcludeClause { candidate, reason }) => {

--- a/src/solver/clause.rs
+++ b/src/solver/clause.rs
@@ -47,7 +47,7 @@ pub(crate) enum Clause {
     ///
     /// In SAT terms: (¬A ∨ B1 ∨ B2 ∨ ... ∨ B99), where B1 to B99 represent the possible candidates
     /// for the provided version set
-    Requires(SolvableId, VersionSetId),
+    Requires(RequiresClause),
     /// Ensures only a single version of a package is installed
     ///
     /// Usage: generate one [`Clause::ForbidMultipleInstances`] clause for each possible combination of
@@ -55,7 +55,7 @@ pub(crate) enum Clause {
     /// the same time.
     ///
     /// In SAT terms: (¬A ∨ ¬B)
-    ForbidMultipleInstances(SolvableId, SolvableId),
+    ForbidMultipleInstances(ForbidMultipleInstancesClause),
     /// Forbids packages that do not satisfy a solvable's constrains
     ///
     /// Usage: for each constrains relationship in a package, determine all the candidates that do
@@ -64,7 +64,7 @@ pub(crate) enum Clause {
     /// pays off to have a separate variant for user-friendly error messages.
     ///
     /// In SAT terms: (¬A ∨ ¬B)
-    Constrains(SolvableId, SolvableId, VersionSetId),
+    Constrains(ConstrainsClause),
     /// Forbids the package on the right-hand side
     ///
     /// Note that the package on the left-hand side is not part of the clause, but just context to
@@ -72,7 +72,7 @@ pub(crate) enum Clause {
     ///
     /// In SAT terms: (¬root ∨ ¬B). Note that we could encode this as an assertion (¬B), but that
     /// would require additional logic in the solver.
-    Lock(SolvableId, SolvableId),
+    Lock(LockClause),
     /// A clause learnt during solving
     ///
     /// The learnt clause id can be used to retrieve the clause's literals, which are stored
@@ -80,129 +80,148 @@ pub(crate) enum Clause {
     Learnt(LearntClauseId),
 
     /// A clause that forbids a package from being installed for an external reason.
-    Excluded(SolvableId, StringId),
+    Excluded(ExcludeClause),
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct RequiresClause {
+    pub candidate: SolvableId,
+    pub requirement: VersionSetId,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct ForbidMultipleInstancesClause {
+    pub from: SolvableId,
+    pub to: SolvableId,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct ConstrainsClause {
+    pub candidate: SolvableId,
+    pub constrained_candidate: SolvableId,
+    pub via: VersionSetId,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct LockClause {
+    pub locked_candidate: SolvableId,
+    pub forbidden_candidate: SolvableId,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct ExcludeClause {
+    pub candidate: SolvableId,
+    pub reason: StringId,
+}
+
+impl From<RequiresClause> for Clause {
+    fn from(requires: RequiresClause) -> Self {
+        Clause::Requires(requires)
+    }
+}
+
+impl From<ForbidMultipleInstancesClause> for Clause {
+    fn from(forbid_multiple: ForbidMultipleInstancesClause) -> Self {
+        Clause::ForbidMultipleInstances(forbid_multiple)
+    }
+}
+
+impl From<ConstrainsClause> for Clause {
+    fn from(constrains: ConstrainsClause) -> Self {
+        Clause::Constrains(constrains)
+    }
+}
+
+impl From<LockClause> for Clause {
+    fn from(lock: LockClause) -> Self {
+        Clause::Lock(lock)
+    }
+}
+
+impl From<LearntClauseId> for Clause {
+    fn from(value: LearntClauseId) -> Self {
+        Clause::Learnt(value)
+    }
+}
+
+impl From<ExcludeClause> for Clause {
+    fn from(value: ExcludeClause) -> Self {
+        Clause::Excluded(value)
+    }
+}
+
+impl ExcludeClause {
+    pub fn visit_literal(&self, mut visit: impl FnMut(Literal)) {
+        visit(Literal {
+            solvable_id: self.candidate,
+            negate: true,
+        });
+    }
+}
+
+impl RequiresClause {
+    pub fn visit_literal(
+        &self,
+        version_set_to_sorted_candidates: &FrozenMap<VersionSetId, Vec<SolvableId>>,
+        mut visit: impl FnMut(Literal),
+    ) {
+        visit(Literal {
+            solvable_id: self.candidate,
+            negate: true,
+        });
+
+        for &solvable_id in &version_set_to_sorted_candidates[&self.requirement] {
+            visit(Literal {
+                solvable_id,
+                negate: false,
+            });
+        }
+    }
+}
+
+impl ForbidMultipleInstancesClause {
+    pub fn visit_literal(&self, mut visit: impl FnMut(Literal)) {
+        visit(Literal {
+            solvable_id: self.from,
+            negate: true,
+        });
+
+        visit(Literal {
+            solvable_id: self.to,
+            negate: true,
+        });
+    }
+}
+
+impl ConstrainsClause {
+    pub fn visit_literal(&self, mut visit: impl FnMut(Literal)) {
+        visit(Literal {
+            solvable_id: self.candidate,
+            negate: true,
+        });
+
+        visit(Literal {
+            solvable_id: self.constrained_candidate,
+            negate: true,
+        });
+    }
+}
+
+impl LockClause {
+    pub fn visit_literal(&self, mut visit: impl FnMut(Literal)) {
+        visit(Literal {
+            solvable_id: SolvableId::root(),
+            negate: true,
+        });
+
+        visit(Literal {
+            solvable_id: self.forbidden_candidate,
+            negate: true,
+        });
+    }
 }
 
 impl Clause {
-    /// Returns the building blocks needed for a new [ClauseState] of the [Clause::Requires] kind.
-    ///
-    /// These building blocks are:
-    ///
-    /// - The [Clause] itself;
-    /// - The ids of the solvables that will be watched (unless there are no candidates, i.e. the
-    ///   clause is actually an assertion);
-    /// - A boolean indicating whether the clause conflicts with existing decisions. This should
-    ///   always be false when adding clauses before starting the solving process, but can be true
-    ///   for clauses that are added dynamically.
-    fn requires(
-        parent: SolvableId,
-        requirement: VersionSetId,
-        candidates: &[SolvableId],
-        decision_tracker: &DecisionTracker,
-    ) -> (Self, Option<[SolvableId; 2]>, bool) {
-        // It only makes sense to introduce a requires clause when the parent solvable is undecided
-        // or going to be installed
-        assert_ne!(decision_tracker.assigned_value(parent), Some(false));
-
-        let kind = Clause::Requires(parent, requirement);
-        if candidates.is_empty() {
-            (kind, None, false)
-        } else {
-            match candidates
-                .iter()
-                .find(|&&c| decision_tracker.assigned_value(c) != Some(false))
-            {
-                // Watch any candidate that is not assigned to false
-                Some(watched_candidate) => (kind, Some([parent, *watched_candidate]), false),
-
-                // All candidates are assigned to false! Therefore the clause conflicts with the
-                // current decisions. There are no valid watches for it at the moment, but we will
-                // assign default ones nevertheless, because they will become valid after the solver
-                // restarts.
-                None => (kind, Some([parent, candidates[0]]), true),
-            }
-        }
-    }
-
-    /// Returns the building blocks needed for a new [ClauseState] of the [Clause::Constrains] kind.
-    ///
-    /// These building blocks are:
-    ///
-    /// - The [Clause] itself;
-    /// - The ids of the solvables that will be watched;
-    /// - A boolean indicating whether the clause conflicts with existing decisions. This should
-    ///   always be false when adding clauses before starting the solving process, but can be true
-    ///   for clauses that are added dynamically.
-    fn constrains(
-        parent: SolvableId,
-        forbidden_solvable: SolvableId,
-        via: VersionSetId,
-        decision_tracker: &DecisionTracker,
-    ) -> (Self, Option<[SolvableId; 2]>, bool) {
-        // It only makes sense to introduce a constrains clause when the parent solvable is
-        // undecided or going to be installed
-        assert_ne!(decision_tracker.assigned_value(parent), Some(false));
-
-        // If the forbidden solvable is already assigned to true, that means that there is a
-        // conflict with current decisions, because it implies the parent solvable would be false
-        // (and we just asserted that it is not)
-        let conflict = decision_tracker.assigned_value(forbidden_solvable) == Some(true);
-
-        (
-            Clause::Constrains(parent, forbidden_solvable, via),
-            Some([parent, forbidden_solvable]),
-            conflict,
-        )
-    }
-
-    /// Returns the ids of the solvables that will be watched as well as the clause itself.
-    fn forbid_multiple(
-        candidate: SolvableId,
-        constrained_candidate: SolvableId,
-    ) -> (Self, Option<[SolvableId; 2]>) {
-        (
-            Clause::ForbidMultipleInstances(candidate, constrained_candidate),
-            Some([candidate, constrained_candidate]),
-        )
-    }
-
-    fn root() -> (Self, Option<[SolvableId; 2]>) {
-        (Clause::InstallRoot, None)
-    }
-
-    fn exclude(candidate: SolvableId, reason: StringId) -> (Self, Option<[SolvableId; 2]>) {
-        (Clause::Excluded(candidate, reason), None)
-    }
-
-    fn lock(
-        locked_candidate: SolvableId,
-        other_candidate: SolvableId,
-    ) -> (Self, Option<[SolvableId; 2]>) {
-        (
-            Clause::Lock(locked_candidate, other_candidate),
-            Some([SolvableId::root(), other_candidate]),
-        )
-    }
-
-    fn learnt(
-        learnt_clause_id: LearntClauseId,
-        literals: &[Literal],
-    ) -> (Self, Option<[SolvableId; 2]>) {
-        debug_assert!(!literals.is_empty());
-        (
-            Clause::Learnt(learnt_clause_id),
-            if literals.len() == 1 {
-                // No need for watches, since we learned an assertion
-                None
-            } else {
-                Some([
-                    literals.first().unwrap().solvable_id,
-                    literals.last().unwrap().solvable_id,
-                ])
-            },
-        )
-    }
-
     /// Visits each literal in the clause
     pub fn visit_literals(
         &self,
@@ -212,52 +231,29 @@ impl Clause {
     ) {
         match *self {
             Clause::InstallRoot => unreachable!(),
-            Clause::Excluded(solvable, _) => {
-                visit(Literal {
-                    solvable_id: solvable,
-                    negate: true,
-                });
-            }
+            Clause::Excluded(clause) => clause.visit_literal(visit),
             Clause::Learnt(learnt_id) => {
                 for &literal in &learnt_clauses[learnt_id] {
                     visit(literal);
                 }
             }
-            Clause::Requires(solvable_id, match_spec_id) => {
-                visit(Literal {
-                    solvable_id,
-                    negate: true,
-                });
-
-                for &solvable_id in &version_set_to_sorted_candidates[&match_spec_id] {
-                    visit(Literal {
-                        solvable_id,
-                        negate: false,
-                    });
-                }
+            Clause::Requires(clause) => {
+                clause.visit_literal(version_set_to_sorted_candidates, visit)
             }
-            Clause::Constrains(s1, s2, _) | Clause::ForbidMultipleInstances(s1, s2) => {
-                visit(Literal {
-                    solvable_id: s1,
-                    negate: true,
-                });
+            Clause::Constrains(clause) => clause.visit_literal(visit),
+            Clause::ForbidMultipleInstances(clause) => clause.visit_literal(visit),
+            Clause::Lock(clause) => clause.visit_literal(visit),
+        }
+    }
 
-                visit(Literal {
-                    solvable_id: s2,
-                    negate: true,
-                });
-            }
-            Clause::Lock(_, s) => {
-                visit(Literal {
-                    solvable_id: SolvableId::root(),
-                    negate: true,
-                });
-
-                visit(Literal {
-                    solvable_id: s,
-                    negate: true,
-                });
-            }
+    /// Returns an object that implements `Debug` to debug the clause.
+    pub fn debug<'pool, VS: VersionSet, N: PackageName + Display>(
+        &self,
+        pool: &'pool Pool<VS, N>,
+    ) -> impl Debug + 'pool {
+        ClauseDebug {
+            clause: *self,
+            pool,
         }
     }
 }
@@ -276,104 +272,16 @@ pub(crate) struct ClauseState {
     // The ids of the next clause in each linked list that this clause is part of
     next_watches: [ClauseId; 2],
     // The clause itself
-    pub(crate) kind: Clause,
+    pub(crate) clause: Clause,
 }
 
 impl ClauseState {
-    /// Shorthand method to construct a [`Clause::InstallRoot`] without requiring complicated
-    /// arguments.
-    pub fn root() -> Self {
-        let (kind, watched_literals) = Clause::root();
-        Self::from_kind_and_initial_watches(kind, watched_literals)
-    }
-
-    /// Shorthand method to construct a [Clause::Requires] without requiring complicated arguments.
-    ///
-    /// The returned boolean value is true when adding the clause resulted in a conflict.
-    pub fn requires(
-        candidate: SolvableId,
-        requirement: VersionSetId,
-        matching_candidates: &[SolvableId],
-        decision_tracker: &DecisionTracker,
-    ) -> (Self, bool) {
-        let (kind, watched_literals, conflict) = Clause::requires(
-            candidate,
-            requirement,
-            matching_candidates,
-            decision_tracker,
-        );
-
-        (
-            Self::from_kind_and_initial_watches(kind, watched_literals),
-            conflict,
-        )
-    }
-
-    /// Shorthand method to construct a [Clause::Constrains] without requiring complicated arguments.
-    ///
-    /// The returned boolean value is true when adding the clause resulted in a conflict.
-    pub fn constrains(
-        candidate: SolvableId,
-        constrained_package: SolvableId,
-        requirement: VersionSetId,
-        decision_tracker: &DecisionTracker,
-    ) -> (Self, bool) {
-        let (kind, watched_literals, conflict) = Clause::constrains(
-            candidate,
-            constrained_package,
-            requirement,
-            decision_tracker,
-        );
-
-        (
-            Self::from_kind_and_initial_watches(kind, watched_literals),
-            conflict,
-        )
-    }
-
-    pub fn lock(locked_candidate: SolvableId, other_candidate: SolvableId) -> Self {
-        let (kind, watched_literals) = Clause::lock(locked_candidate, other_candidate);
-        Self::from_kind_and_initial_watches(kind, watched_literals)
-    }
-
-    pub fn forbid_multiple(candidate: SolvableId, other_candidate: SolvableId) -> Self {
-        let (kind, watched_literals) = Clause::forbid_multiple(candidate, other_candidate);
-        Self::from_kind_and_initial_watches(kind, watched_literals)
-    }
-
-    pub fn learnt(learnt_clause_id: LearntClauseId, literals: &[Literal]) -> Self {
-        let (kind, watched_literals) = Clause::learnt(learnt_clause_id, literals);
-        Self::from_kind_and_initial_watches(kind, watched_literals)
-    }
-
-    pub fn exclude(candidate: SolvableId, reason: StringId) -> Self {
-        let (kind, watched_literals) = Clause::exclude(candidate, reason);
-        Self::from_kind_and_initial_watches(kind, watched_literals)
-    }
-
-    fn from_kind_and_initial_watches(
-        kind: Clause,
-        watched_literals: Option<[SolvableId; 2]>,
-    ) -> Self {
-        let watched_literals = watched_literals.unwrap_or([SolvableId::null(), SolvableId::null()]);
-
-        let clause = Self {
-            watched_literals,
-            next_watches: [ClauseId::null(), ClauseId::null()],
-            kind,
-        };
-
-        debug_assert!(!clause.has_watches() || watched_literals[0] != watched_literals[1]);
-
-        clause
-    }
-
     pub fn debug<'a, VS: VersionSet, N: PackageName>(
         &self,
         pool: &'a Pool<VS, N>,
     ) -> ClauseDebug<'a, VS, N> {
         ClauseDebug {
-            kind: self.kind,
+            clause: self.clause,
             pool,
         }
     }
@@ -452,9 +360,8 @@ impl ClauseState {
             ]
         };
 
-        match self.kind {
-            Clause::InstallRoot => unreachable!(),
-            Clause::Excluded(_, _) => unreachable!(),
+        match self.clause {
+            Clause::InstallRoot | Clause::Excluded(..) => unreachable!(),
             Clause::Learnt(learnt_id) => {
                 // TODO: we might want to do something else for performance, like keeping the whole
                 // literal in `self.watched_literals`, to avoid lookups... But first we should
@@ -472,10 +379,10 @@ impl ClauseState {
             Clause::Constrains(..) | Clause::ForbidMultipleInstances(..) | Clause::Lock(..) => {
                 literals(false, false)
             }
-            Clause::Requires(solvable_id, _) => {
-                if self.watched_literals[0] == solvable_id {
+            Clause::Requires(RequiresClause { candidate, .. }) => {
+                if self.watched_literals[0] == candidate {
                     literals(false, true)
-                } else if self.watched_literals[1] == solvable_id {
+                } else if self.watched_literals[1] == candidate {
                     literals(true, false)
                 } else {
                     literals(true, true)
@@ -498,27 +405,27 @@ impl ClauseState {
                 && solvable_lit.eval(decision_map).unwrap_or(true)
         };
 
-        match self.kind {
+        match self.clause {
             Clause::InstallRoot => unreachable!(),
-            Clause::Excluded(_, _) => unreachable!(),
+            Clause::Excluded(_) => unreachable!(),
             Clause::Learnt(learnt_id) => learnt_clauses[learnt_id]
                 .iter()
                 .cloned()
                 .find(|&l| can_watch(l))
                 .map(|l| l.solvable_id),
             Clause::Constrains(..) | Clause::ForbidMultipleInstances(..) | Clause::Lock(..) => None,
-            Clause::Requires(solvable_id, version_set_id) => {
+            Clause::Requires(clause) => {
                 // The solvable that added this clause
                 let solvable_lit = Literal {
-                    solvable_id,
+                    solvable_id: clause.candidate,
                     negate: true,
                 };
                 if can_watch(solvable_lit) {
-                    return Some(solvable_id);
+                    return Some(clause.candidate);
                 }
 
                 // The available candidates
-                for &candidate in &version_set_to_sorted_candidates[&version_set_id] {
+                for &candidate in &version_set_to_sorted_candidates[&clause.requirement] {
                     let lit = Literal {
                         solvable_id: candidate,
                         negate: false,
@@ -566,55 +473,65 @@ impl Literal {
 
 /// A representation of a clause that implements [`Debug`]
 pub(crate) struct ClauseDebug<'pool, VS: VersionSet, N: PackageName> {
-    kind: Clause,
+    clause: Clause,
     pool: &'pool Pool<VS, N>,
 }
 
 impl<VS: VersionSet, N: PackageName + Display> Debug for ClauseDebug<'_, VS, N> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self.kind {
+        match self.clause {
             Clause::InstallRoot => write!(f, "install root"),
-            Clause::Excluded(solvable_id, reason) => {
+            Clause::Excluded(ExcludeClause { candidate, reason }) => {
                 write!(
                     f,
                     "{} excluded because: {}",
-                    solvable_id.display(self.pool),
+                    candidate.display(self.pool),
                     self.pool.resolve_string(reason)
                 )
             }
             Clause::Learnt(learnt_id) => write!(f, "learnt clause {learnt_id:?}"),
-            Clause::Requires(solvable_id, match_spec_id) => {
-                let match_spec = self.pool.resolve_version_set(match_spec_id).to_string();
+            Clause::Requires(RequiresClause {
+                candidate,
+                requirement,
+            }) => {
+                let match_spec = self.pool.resolve_version_set(requirement).to_string();
                 write!(
                     f,
                     "{} requires {} {match_spec}",
-                    solvable_id.display(self.pool),
+                    candidate.display(self.pool),
                     self.pool
-                        .resolve_version_set_package_name(match_spec_id)
+                        .resolve_version_set_package_name(requirement)
                         .display(self.pool)
                 )
             }
-            Clause::Constrains(s1, s2, vset_id) => {
+            Clause::Constrains(ConstrainsClause {
+                candidate,
+                constrained_candidate,
+                via,
+            }) => {
                 write!(
                     f,
                     "{} excludes {} by {}",
-                    s1.display(self.pool),
-                    s2.display(self.pool),
-                    self.pool.resolve_version_set(vset_id)
+                    candidate.display(self.pool),
+                    constrained_candidate.display(self.pool),
+                    self.pool.resolve_version_set(via)
                 )
             }
-            Clause::Lock(locked, forbidden) => {
+            Clause::Lock(LockClause {
+                locked_candidate,
+                forbidden_candidate: other_candidate,
+            }) => {
                 write!(
                     f,
                     "{} is locked, so {} is forbidden",
-                    locked.display(self.pool),
-                    forbidden.display(self.pool)
+                    locked_candidate.display(self.pool),
+                    other_candidate.display(self.pool)
                 )
             }
-            Clause::ForbidMultipleInstances(s1, _) => {
+            Clause::ForbidMultipleInstances(ForbidMultipleInstancesClause { from, .. }) => {
                 let name = self
                     .pool
-                    .resolve_internal_solvable(s1)
+                    .resolve_internal_solvable(from)
                     .solvable()
                     .name
                     .display(self.pool);
@@ -624,252 +541,419 @@ impl<VS: VersionSet, N: PackageName + Display> Debug for ClauseDebug<'_, VS, N> 
     }
 }
 
-#[cfg(test)]
-mod test {
-    use super::*;
-    use crate::internal::arena::ArenaId;
-    use crate::solver::decision::Decision;
+#[derive(Default)]
+pub struct Clauses {
+    clauses: Arena<ClauseId, ClauseState>,
+}
 
-    fn clause(next_clauses: [ClauseId; 2], watched_solvables: [SolvableId; 2]) -> ClauseState {
-        ClauseState {
-            watched_literals: watched_solvables,
-            next_watches: next_clauses,
+impl Clauses {
+    /// Allocates a new [`Clause::Requires`] clause.
+    pub fn alloc_requires(
+        &mut self,
+        candidate: SolvableId,
+        requirement: VersionSetId,
+        resolved_candidates: &[SolvableId],
+        decision_tracker: &DecisionTracker,
+    ) -> (ClauseId, bool) {
+        // It only makes sense to introduce a requires clause when the parent solvable is undecided
+        // or going to be installed
+        assert_ne!(decision_tracker.assigned_value(candidate), Some(false));
 
-            // The kind is irrelevant here
-            kind: Clause::InstallRoot,
-        }
-    }
-
-    #[test]
-    #[allow(clippy::bool_assert_comparison)]
-    fn test_literal_satisfying_value() {
-        let lit = Literal {
-            solvable_id: SolvableId::root(),
-            negate: true,
+        let clause = RequiresClause {
+            candidate,
+            requirement,
         };
-        assert_eq!(lit.satisfying_value(), false);
+        let (watched_literals, conflict) = if resolved_candidates.is_empty() {
+            (None, false)
+        } else {
+            match resolved_candidates
+                .iter()
+                .find(|&&c| decision_tracker.assigned_value(c) != Some(false))
+            {
+                // Watch any candidate that is not assigned to false
+                Some(watched_candidate) => (Some([candidate, *watched_candidate]), false),
 
-        let lit = Literal {
-            solvable_id: SolvableId::root(),
-            negate: false,
-        };
-        assert_eq!(lit.satisfying_value(), true);
-    }
-
-    #[test]
-    fn test_literal_eval() {
-        let mut decision_map = DecisionMap::new();
-
-        let literal = Literal {
-            solvable_id: SolvableId::root(),
-            negate: false,
-        };
-        let negated_literal = Literal {
-            solvable_id: SolvableId::root(),
-            negate: true,
+                // All candidates are assigned to false! Therefore the clause conflicts with the
+                // current decisions. There are no valid watches for it at the moment, but we will
+                // assign default ones nevertheless, because they will become valid after the solver
+                // restarts.
+                None => (Some([candidate, resolved_candidates[0]]), true),
+            }
         };
 
-        // Undecided
-        assert_eq!(literal.eval(&decision_map), None);
-        assert_eq!(negated_literal.eval(&decision_map), None);
-
-        // Decided
-        decision_map.set(SolvableId::root(), true, 1);
-        assert_eq!(literal.eval(&decision_map), Some(true));
-        assert_eq!(negated_literal.eval(&decision_map), Some(false));
-
-        decision_map.set(SolvableId::root(), false, 1);
-        assert_eq!(literal.eval(&decision_map), Some(false));
-        assert_eq!(negated_literal.eval(&decision_map), Some(true));
+        let clause_id = self.alloc(clause, watched_literals);
+        (clause_id, conflict)
     }
 
-    #[test]
-    fn test_unlink_clause_different() {
-        let clause1 = clause(
-            [ClauseId::from_usize(2), ClauseId::from_usize(3)],
-            [SolvableId::from_usize(1596), SolvableId::from_usize(1211)],
-        );
-        let clause2 = clause(
-            [ClauseId::null(), ClauseId::from_usize(3)],
-            [SolvableId::from_usize(1596), SolvableId::from_usize(1208)],
-        );
-        let clause3 = clause(
-            [ClauseId::null(), ClauseId::null()],
-            [SolvableId::from_usize(1211), SolvableId::from_usize(42)],
+    /// Allocates a new [`Clause::Constrains`] clause.
+    pub fn alloc_constrains(
+        &mut self,
+        candidate: SolvableId,
+        constrained_candidate: SolvableId,
+        requires_clause: VersionSetId,
+        decision_tracker: &DecisionTracker,
+    ) -> (ClauseId, bool) {
+        // It only makes sense to introduce a constrains clause when the parent solvable is
+        // undecided or going to be installed
+        assert_ne!(decision_tracker.assigned_value(candidate), Some(false));
+
+        // If the forbidden solvable is already assigned to true, that means that there is a
+        // conflict with current decisions, because it implies the parent solvable would be false
+        // (and we just asserted that it is not)
+        let conflict = decision_tracker.assigned_value(constrained_candidate) == Some(true);
+
+        let clause_id = self.alloc(
+            ConstrainsClause {
+                candidate,
+                constrained_candidate,
+                via: requires_clause,
+            },
+            Some([candidate, constrained_candidate]),
         );
 
-        // Unlink 0
-        {
-            let mut clause1 = clause1.clone();
-            clause1.unlink_clause(&clause2, SolvableId::from_usize(1596), 0);
-            assert_eq!(
-                clause1.watched_literals,
-                [SolvableId::from_usize(1596), SolvableId::from_usize(1211)]
-            );
-            assert_eq!(
-                clause1.next_watches,
-                [ClauseId::null(), ClauseId::from_usize(3)]
-            )
-        }
-
-        // Unlink 1
-        {
-            let mut clause1 = clause1;
-            clause1.unlink_clause(&clause3, SolvableId::from_usize(1211), 0);
-            assert_eq!(
-                clause1.watched_literals,
-                [SolvableId::from_usize(1596), SolvableId::from_usize(1211)]
-            );
-            assert_eq!(
-                clause1.next_watches,
-                [ClauseId::from_usize(2), ClauseId::null()]
-            )
-        }
+        (clause_id, conflict)
     }
 
-    #[test]
-    fn test_unlink_clause_same() {
-        let clause1 = clause(
-            [ClauseId::from_usize(2), ClauseId::from_usize(2)],
-            [SolvableId::from_usize(1596), SolvableId::from_usize(1211)],
-        );
-        let clause2 = clause(
-            [ClauseId::null(), ClauseId::null()],
-            [SolvableId::from_usize(1596), SolvableId::from_usize(1211)],
-        );
+    /// Allocates a new [`Clause::ForbidMultipleInstances`] clause.
+    pub fn alloc_forbid_multiple(
+        &mut self,
+        candidates: SolvableId,
+        constrained_candidate: SolvableId,
+    ) -> ClauseId {
+        let clause = ForbidMultipleInstancesClause {
+            from: candidates,
+            to: constrained_candidate,
+        };
 
-        // Unlink 0
-        {
-            let mut clause1 = clause1.clone();
-            clause1.unlink_clause(&clause2, SolvableId::from_usize(1596), 0);
-            assert_eq!(
-                clause1.watched_literals,
-                [SolvableId::from_usize(1596), SolvableId::from_usize(1211)]
-            );
-            assert_eq!(
-                clause1.next_watches,
-                [ClauseId::null(), ClauseId::from_usize(2)]
-            )
-        }
-
-        // Unlink 1
-        {
-            let mut clause1 = clause1;
-            clause1.unlink_clause(&clause2, SolvableId::from_usize(1211), 1);
-            assert_eq!(
-                clause1.watched_literals,
-                [SolvableId::from_usize(1596), SolvableId::from_usize(1211)]
-            );
-            assert_eq!(
-                clause1.next_watches,
-                [ClauseId::from_usize(2), ClauseId::null()]
-            )
-        }
+        self.alloc(clause, Some([candidates, constrained_candidate]))
     }
 
-    #[test]
-    fn test_requires_with_and_without_conflict() {
-        let mut decisions = DecisionTracker::new();
-
-        let parent = SolvableId::from_usize(1);
-        let candidate1 = SolvableId::from_usize(2);
-        let candidate2 = SolvableId::from_usize(3);
-
-        // No conflict, all candidates available
-        let (clause, conflict) = ClauseState::requires(
-            parent,
-            VersionSetId::from_usize(0),
-            &[candidate1, candidate2],
-            &decisions,
-        );
-        assert!(!conflict);
-        assert_eq!(clause.watched_literals[0], parent);
-        assert_eq!(clause.watched_literals[1], candidate1);
-
-        // No conflict, still one candidate available
-        decisions
-            .try_add_decision(Decision::new(candidate1, false, ClauseId::null()), 1)
-            .unwrap();
-        let (clause, conflict) = ClauseState::requires(
-            parent,
-            VersionSetId::from_usize(0),
-            &[candidate1, candidate2],
-            &decisions,
-        );
-        assert!(!conflict);
-        assert_eq!(clause.watched_literals[0], parent);
-        assert_eq!(clause.watched_literals[1], candidate2);
-
-        // Conflict, no candidates available
-        decisions
-            .try_add_decision(Decision::new(candidate2, false, ClauseId::null()), 1)
-            .unwrap();
-        let (clause, conflict) = ClauseState::requires(
-            parent,
-            VersionSetId::from_usize(0),
-            &[candidate1, candidate2],
-            &decisions,
-        );
-        assert!(conflict);
-        assert_eq!(clause.watched_literals[0], parent);
-        assert_eq!(clause.watched_literals[1], candidate1);
-
-        // Panic
-        decisions
-            .try_add_decision(Decision::new(parent, false, ClauseId::null()), 1)
-            .unwrap();
-        let panicked = std::panic::catch_unwind(|| {
-            ClauseState::requires(
-                parent,
-                VersionSetId::from_usize(0),
-                &[candidate1, candidate2],
-                &decisions,
-            )
-        })
-        .is_err();
-        assert!(panicked);
+    /// Allocates a new [`Clause::InstallRoot`] clause.
+    pub fn alloc_root(&mut self) -> ClauseId {
+        self.alloc(Clause::InstallRoot, None)
     }
 
-    #[test]
-    fn test_constrains_with_and_without_conflict() {
-        let mut decisions = DecisionTracker::new();
-
-        let parent = SolvableId::from_usize(1);
-        let forbidden = SolvableId::from_usize(2);
-
-        // No conflict, forbidden package not installed
-        let (clause, conflict) =
-            ClauseState::constrains(parent, forbidden, VersionSetId::from_usize(0), &decisions);
-        assert!(!conflict);
-        assert_eq!(clause.watched_literals[0], parent);
-        assert_eq!(clause.watched_literals[1], forbidden);
-
-        // Conflict, forbidden package installed
-        decisions
-            .try_add_decision(Decision::new(forbidden, true, ClauseId::null()), 1)
-            .unwrap();
-        let (clause, conflict) =
-            ClauseState::constrains(parent, forbidden, VersionSetId::from_usize(0), &decisions);
-        assert!(conflict);
-        assert_eq!(clause.watched_literals[0], parent);
-        assert_eq!(clause.watched_literals[1], forbidden);
-
-        // Panic
-        decisions
-            .try_add_decision(Decision::new(parent, false, ClauseId::null()), 1)
-            .unwrap();
-        let panicked = std::panic::catch_unwind(|| {
-            ClauseState::constrains(parent, forbidden, VersionSetId::from_usize(0), &decisions)
-        })
-        .is_err();
-        assert!(panicked);
+    /// Allocates a new [`Clause::Excluded`] clause.
+    pub fn alloc_exclude(&mut self, candidate: SolvableId, reason: StringId) -> ClauseId {
+        self.alloc(Clause::Excluded(ExcludeClause { candidate, reason }), None)
     }
 
-    #[test]
-    fn test_clause_size() {
-        // This test is here to ensure we don't increase the size of `ClauseState` by accident, as
-        // we are creating thousands of instances. Note: libsolv manages to bring down the size to
-        // 24, so there is probably room for improvement.
-        assert_eq!(std::mem::size_of::<ClauseState>(), 32);
+    /// Allocates a new [`Clause::Learnt`] clause.
+    pub fn alloc_learnt(
+        &mut self,
+        learnt_clause_id: LearntClauseId,
+        literals: &[Literal],
+    ) -> ClauseId {
+        debug_assert!(!literals.is_empty());
+        let watched_literals = if literals.len() == 1 {
+            // Not need for watches, since we learned an assertion
+            None
+        } else {
+            Some([literals[0].solvable_id, literals[1].solvable_id])
+        };
+
+        self.alloc(Clause::Learnt(learnt_clause_id), watched_literals)
+    }
+
+    /// Allocates a new [`Clause::Lock`] clause.
+    pub fn alloc_lock(
+        &mut self,
+        locked_candidate: SolvableId,
+        other_candidate: SolvableId,
+    ) -> ClauseId {
+        self.alloc(
+            Clause::Lock(LockClause {
+                locked_candidate,
+                forbidden_candidate: other_candidate,
+            }),
+            Some([SolvableId::root(), other_candidate]),
+        )
+    }
+
+    fn alloc(
+        &mut self,
+        clause: impl Into<Clause>,
+        watched_literals: Option<[SolvableId; 2]>,
+    ) -> ClauseId {
+        let watched_literals = watched_literals.unwrap_or([SolvableId::null(), SolvableId::null()]);
+
+        let clause = ClauseState {
+            watched_literals,
+            next_watches: [ClauseId::null(), ClauseId::null()],
+            clause: clause.into(),
+        };
+
+        debug_assert!(!clause.has_watches() || watched_literals[0] != watched_literals[1]);
+
+        self.clauses.alloc(clause)
+    }
+
+    /// Returns the clause with the given id.
+    pub fn clause(&self, id: ClauseId) -> Clause {
+        self.clauses[id].clause
+    }
+
+    /// Returns the clause with the given id.
+    pub fn clause_state_mut(&mut self, id: ClauseId) -> &mut ClauseState {
+        &mut self.clauses[id]
+    }
+
+    /// Returns two clause states with the given ids.
+    pub fn two_clause_state_mut(&mut self, a: ClauseId, b: ClauseId) -> (&mut ClauseState, &mut ClauseState) {
+        self.clauses.get_two_mut(a, b)
+    }
+
+    pub fn has_watches(&self, id: ClauseId) -> bool {
+        self.clauses[id].has_watches()
     }
 }
+
+// #[cfg(test)]
+// mod test {
+//     use super::*;
+//     use crate::internal::arena::ArenaId;
+//     use crate::solver::decision::Decision;
+//
+//     fn clause(next_clauses: [ClauseId; 2], watched_solvables: [SolvableId; 2]) -> ClauseState {
+//         ClauseState {
+//             watched_literals: watched_solvables,
+//             next_watches: next_clauses,
+//
+//             // The kind is irrelevant here
+//             clause: Clause::InstallRoot,
+//         }
+//     }
+//
+//     #[test]
+//     #[allow(clippy::bool_assert_comparison)]
+//     fn test_literal_satisfying_value() {
+//         let lit = Literal {
+//             solvable_id: SolvableId::root(),
+//             negate: true,
+//         };
+//         assert_eq!(lit.satisfying_value(), false);
+//
+//         let lit = Literal {
+//             solvable_id: SolvableId::root(),
+//             negate: false,
+//         };
+//         assert_eq!(lit.satisfying_value(), true);
+//     }
+//
+//     #[test]
+//     fn test_literal_eval() {
+//         let mut decision_map = DecisionMap::new();
+//
+//         let literal = Literal {
+//             solvable_id: SolvableId::root(),
+//             negate: false,
+//         };
+//         let negated_literal = Literal {
+//             solvable_id: SolvableId::root(),
+//             negate: true,
+//         };
+//
+//         // Undecided
+//         assert_eq!(literal.eval(&decision_map), None);
+//         assert_eq!(negated_literal.eval(&decision_map), None);
+//
+//         // Decided
+//         decision_map.set(SolvableId::root(), true, 1);
+//         assert_eq!(literal.eval(&decision_map), Some(true));
+//         assert_eq!(negated_literal.eval(&decision_map), Some(false));
+//
+//         decision_map.set(SolvableId::root(), false, 1);
+//         assert_eq!(literal.eval(&decision_map), Some(false));
+//         assert_eq!(negated_literal.eval(&decision_map), Some(true));
+//     }
+//
+//     #[test]
+//     fn test_unlink_clause_different() {
+//         let clause1 = clause(
+//             [ClauseId::from_usize(2), ClauseId::from_usize(3)],
+//             [SolvableId::from_usize(1596), SolvableId::from_usize(1211)],
+//         );
+//         let clause2 = clause(
+//             [ClauseId::null(), ClauseId::from_usize(3)],
+//             [SolvableId::from_usize(1596), SolvableId::from_usize(1208)],
+//         );
+//         let clause3 = clause(
+//             [ClauseId::null(), ClauseId::null()],
+//             [SolvableId::from_usize(1211), SolvableId::from_usize(42)],
+//         );
+//
+//         // Unlink 0
+//         {
+//             let mut clause1 = clause1.clone();
+//             clause1.unlink_clause(&clause2, SolvableId::from_usize(1596), 0);
+//             assert_eq!(
+//                 clause1.watched_literals,
+//                 [SolvableId::from_usize(1596), SolvableId::from_usize(1211)]
+//             );
+//             assert_eq!(
+//                 clause1.next_watches,
+//                 [ClauseId::null(), ClauseId::from_usize(3)]
+//             )
+//         }
+//
+//         // Unlink 1
+//         {
+//             let mut clause1 = clause1;
+//             clause1.unlink_clause(&clause3, SolvableId::from_usize(1211), 0);
+//             assert_eq!(
+//                 clause1.watched_literals,
+//                 [SolvableId::from_usize(1596), SolvableId::from_usize(1211)]
+//             );
+//             assert_eq!(
+//                 clause1.next_watches,
+//                 [ClauseId::from_usize(2), ClauseId::null()]
+//             )
+//         }
+//     }
+//
+//     #[test]
+//     fn test_unlink_clause_same() {
+//         let clause1 = clause(
+//             [ClauseId::from_usize(2), ClauseId::from_usize(2)],
+//             [SolvableId::from_usize(1596), SolvableId::from_usize(1211)],
+//         );
+//         let clause2 = clause(
+//             [ClauseId::null(), ClauseId::null()],
+//             [SolvableId::from_usize(1596), SolvableId::from_usize(1211)],
+//         );
+//
+//         // Unlink 0
+//         {
+//             let mut clause1 = clause1.clone();
+//             clause1.unlink_clause(&clause2, SolvableId::from_usize(1596), 0);
+//             assert_eq!(
+//                 clause1.watched_literals,
+//                 [SolvableId::from_usize(1596), SolvableId::from_usize(1211)]
+//             );
+//             assert_eq!(
+//                 clause1.next_watches,
+//                 [ClauseId::null(), ClauseId::from_usize(2)]
+//             )
+//         }
+//
+//         // Unlink 1
+//         {
+//             let mut clause1 = clause1;
+//             clause1.unlink_clause(&clause2, SolvableId::from_usize(1211), 1);
+//             assert_eq!(
+//                 clause1.watched_literals,
+//                 [SolvableId::from_usize(1596), SolvableId::from_usize(1211)]
+//             );
+//             assert_eq!(
+//                 clause1.next_watches,
+//                 [ClauseId::from_usize(2), ClauseId::null()]
+//             )
+//         }
+//     }
+//
+//     #[test]
+//     fn test_requires_with_and_without_conflict() {
+//         let mut decisions = DecisionTracker::new();
+//
+//         let parent = SolvableId::from_usize(1);
+//         let candidate1 = SolvableId::from_usize(2);
+//         let candidate2 = SolvableId::from_usize(3);
+//
+//         // No conflict, all candidates available
+//         let (clause, conflict) = ClauseState::requires(
+//             parent,
+//             VersionSetId::from_usize(0),
+//             &[candidate1, candidate2],
+//             &decisions,
+//         );
+//         assert!(!conflict);
+//         assert_eq!(clause.watched_literals[0], parent);
+//         assert_eq!(clause.watched_literals[1], candidate1);
+//
+//         // No conflict, still one candidate available
+//         decisions
+//             .try_add_decision(Decision::new(candidate1, false, ClauseId::null()), 1)
+//             .unwrap();
+//         let (clause, conflict) = ClauseState::requires(
+//             parent,
+//             VersionSetId::from_usize(0),
+//             &[candidate1, candidate2],
+//             &decisions,
+//         );
+//         assert!(!conflict);
+//         assert_eq!(clause.watched_literals[0], parent);
+//         assert_eq!(clause.watched_literals[1], candidate2);
+//
+//         // Conflict, no candidates available
+//         decisions
+//             .try_add_decision(Decision::new(candidate2, false, ClauseId::null()), 1)
+//             .unwrap();
+//         let (clause, conflict) = ClauseState::requires(
+//             parent,
+//             VersionSetId::from_usize(0),
+//             &[candidate1, candidate2],
+//             &decisions,
+//         );
+//         assert!(conflict);
+//         assert_eq!(clause.watched_literals[0], parent);
+//         assert_eq!(clause.watched_literals[1], candidate1);
+//
+//         // Panic
+//         decisions
+//             .try_add_decision(Decision::new(parent, false, ClauseId::null()), 1)
+//             .unwrap();
+//         let panicked = std::panic::catch_unwind(|| {
+//             ClauseState::requires(
+//                 parent,
+//                 VersionSetId::from_usize(0),
+//                 &[candidate1, candidate2],
+//                 &decisions,
+//             )
+//         })
+//         .is_err();
+//         assert!(panicked);
+//     }
+//
+//     #[test]
+//     fn test_constrains_with_and_without_conflict() {
+//         let mut decisions = DecisionTracker::new();
+//
+//         let parent = SolvableId::from_usize(1);
+//         let forbidden = SolvableId::from_usize(2);
+//
+//         // No conflict, forbidden package not installed
+//         let (clause, conflict) =
+//             ClauseState::constrains(parent, forbidden, VersionSetId::from_usize(0), &decisions);
+//         assert!(!conflict);
+//         assert_eq!(clause.watched_literals[0], parent);
+//         assert_eq!(clause.watched_literals[1], forbidden);
+//
+//         // Conflict, forbidden package installed
+//         decisions
+//             .try_add_decision(Decision::new(forbidden, true, ClauseId::null()), 1)
+//             .unwrap();
+//         let (clause, conflict) =
+//             ClauseState::constrains(parent, forbidden, VersionSetId::from_usize(0), &decisions);
+//         assert!(conflict);
+//         assert_eq!(clause.watched_literals[0], parent);
+//         assert_eq!(clause.watched_literals[1], forbidden);
+//
+//         // Panic
+//         decisions
+//             .try_add_decision(Decision::new(parent, false, ClauseId::null()), 1)
+//             .unwrap();
+//         let panicked = std::panic::catch_unwind(|| {
+//             ClauseState::constrains(parent, forbidden, VersionSetId::from_usize(0), &decisions)
+//         })
+//         .is_err();
+//         assert!(panicked);
+//     }
+//
+//     #[test]
+//     fn test_clause_size() {
+//         // This test is here to ensure we don't increase the size of `ClauseState` by accident, as
+//         // we are creating thousands of instances. Note: libsolv manages to bring down the size to
+//         // 24, so there is probably room for improvement.
+//         assert_eq!(std::mem::size_of::<ClauseState>(), 32);
+//     }
+// }

--- a/src/solver/decision.rs
+++ b/src/solver/decision.rs
@@ -1,4 +1,5 @@
-use crate::internal::id::{ClauseId, SolvableId};
+use crate::internal::id::{ SolvableId};
+use crate::solver::clause::ClauseId;
 
 /// Represents an assignment to a variable
 #[derive(Copy, Clone, Eq, PartialEq)]

--- a/src/solver/decision_tracker.rs
+++ b/src/solver/decision_tracker.rs
@@ -1,7 +1,6 @@
-use crate::internal::id::ClauseId;
 use crate::{
     internal::id::SolvableId,
-    solver::{decision::Decision, decision_map::DecisionMap},
+    solver::{clause::ClauseId, decision::Decision, decision_map::DecisionMap},
 };
 
 /// Tracks the assignments to solvables, keeping a log that can be used to backtrack, and a map that

--- a/src/solver/watch_map.rs
+++ b/src/solver/watch_map.rs
@@ -1,6 +1,6 @@
 use crate::{
-    internal::{id::ClauseId, id::SolvableId, mapping::Mapping},
-    solver::clause::ClauseState,
+    internal::{id::SolvableId, mapping::Mapping},
+    solver::clause::{ClauseId, ClauseState},
 };
 
 /// A map from solvables to the clauses that are watching them


### PR DESCRIPTION
Reduce the total memory used by the solver by grouping similar datatypes together. There is still some unsafe code in here, which I want to try and clean up a little more.