### PR TITLE
feat: root constraints

### DIFF
--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -1,3 +1,16 @@
+use std::{
+    any::Any, cell::RefCell, collections::HashSet, fmt::Display, future::ready, ops::ControlFlow,
+    rc::Rc,
+};
+
+pub use cache::SolverCache;
+use clause::{Clause, ClauseState, Literal};
+use decision::Decision;
+use decision_tracker::DecisionTracker;
+use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
+use itertools::{chain, Itertools};
+use watch_map::WatchMap;
+
 use crate::{
     internal::{
         arena::Arena,
@@ -6,28 +19,11 @@ use crate::{
     },
     pool::Pool,
     problem::Problem,
+    runtime::{AsyncRuntime, NowOrNeverRuntime},
     solvable::SolvableInner,
     Candidates, Dependencies, DependencyProvider, KnownDependencies, PackageName, VersionSet,
     VersionSetId,
 };
-use futures::stream::FuturesUnordered;
-use futures::{FutureExt, StreamExt};
-use std::any::Any;
-use std::cell::RefCell;
-use std::collections::HashSet;
-use std::fmt::Display;
-use std::future::ready;
-use std::ops::ControlFlow;
-use std::rc::Rc;
-
-use itertools::{chain, Itertools};
-
-use crate::runtime::{AsyncRuntime, NowOrNeverRuntime};
-pub use cache::SolverCache;
-use clause::{Clause, ClauseState, Literal};
-use decision::Decision;
-use decision_tracker::DecisionTracker;
-use watch_map::WatchMap;
 
 mod cache;
 pub(crate) mod clause;
@@ -73,6 +69,9 @@ pub struct Solver<
 
     /// The version sets that must be installed as part of the solution.
     root_requirements: Vec<VersionSetId>,
+
+    /// Additional constraints imposed by the root.
+    root_constraints: Vec<VersionSetId>,
 }
 
 impl<VS: VersionSet, N: PackageName, D: DependencyProvider<VS, N>>
@@ -94,6 +93,7 @@ impl<VS: VersionSet, N: PackageName, D: DependencyProvider<VS, N>>
             learnt_clause_ids: Vec::new(),
             decision_tracker: DecisionTracker::new(),
             root_requirements: Default::default(),
+            root_constraints: Default::default(),
             clauses_added_for_package: Default::default(),
             clauses_added_for_solvable: Default::default(),
         }
@@ -147,16 +147,21 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
             clauses_added_for_solvable: self.clauses_added_for_solvable,
             decision_tracker: self.decision_tracker,
             root_requirements: self.root_requirements,
+            root_constraints: self.root_constraints,
         }
     }
 
-    /// Solves the provided `jobs` and returns a transaction from the found solution
+    /// Solves for the provided `root_requirements` and `root_constraints`. The
+    /// `root_requirements` are package that will be included in the
+    /// solution. `root_constraints` are additional constrains which do not
+    /// necesarily need to be included in the solution.
     ///
-    /// Returns a [`Problem`] if no solution was found, which provides ways to inspect the causes
-    /// and report them to the user.
+    /// Returns a [`Problem`] if no solution was found, which provides ways to
+    /// inspect the causes and report them to the user.
     pub fn solve(
         &mut self,
         root_requirements: Vec<VersionSetId>,
+        root_constraints: Vec<VersionSetId>,
     ) -> Result<Vec<SolvableId>, UnsolvableOrCancelled> {
         // Clear state
         self.decision_tracker.clear();
@@ -165,9 +170,10 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
         self.learnt_why = Mapping::new();
         self.clauses = Default::default();
         self.root_requirements = root_requirements;
+        self.root_constraints = root_constraints;
 
-        // The first clause will always be the install root clause. Here we verify that this is
-        // indeed the case.
+        // The first clause will always be the install root clause. Here we verify that
+        // this is indeed the case.
         let root_clause = self.clauses.borrow_mut().alloc(ClauseState::root());
         assert_eq!(root_clause, ClauseId::install_root());
 
@@ -190,13 +196,14 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
         Ok(steps)
     }
 
-    /// Adds clauses for a solvable. These clauses include requirements and constrains on other
-    /// solvables.
+    /// Adds clauses for a solvable. These clauses include requirements and
+    /// constrains on other solvables.
     ///
-    /// Returns the added clauses, and an additional list with conflicting clauses (if any).
+    /// Returns the added clauses, and an additional list with conflicting
+    /// clauses (if any).
     ///
-    /// If the provider has requested the solving process to be cancelled, the cancellation value
-    /// will be returned as an `Err(...)`.
+    /// If the provider has requested the solving process to be cancelled, the
+    /// cancellation value will be returned as an `Err(...)`.
     async fn add_clauses_for_solvables(
         &self,
         solvable_ids: impl IntoIterator<Item = SolvableId>,
@@ -252,7 +259,7 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
                         solvable_id,
                         dependencies: Dependencies::Known(KnownDependencies {
                             requirements: self.root_requirements.clone(),
-                            constrains: vec![],
+                            constrains: self.root_constraints.clone(),
                         }),
                     }))
                     .left_future(),
@@ -299,7 +306,8 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
                                 .borrow_mut()
                                 .alloc(ClauseState::exclude(solvable_id, reason));
 
-                            // Exclusions are negative assertions, tracked outside of the watcher system
+                            // Exclusions are negative assertions, tracked outside of the watcher
+                            // system
                             output.negative_assertions.push((solvable_id, clause_id));
 
                             // There might be a conflict now
@@ -382,7 +390,8 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
                     let locked_solvable_id = package_candidates.locked;
                     let candidates = &package_candidates.candidates;
 
-                    // Check the assumption that no decision has been made about any of the solvables.
+                    // Check the assumption that no decision has been made about any of the
+                    // solvables.
                     for &candidate in candidates {
                         debug_assert!(
                             self.decision_tracker.assigned_value(candidate).is_none(),
@@ -447,8 +456,8 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
                         version_set
                     );
 
-                    // Queue requesting the dependencies of the candidates as well if they are cheaply
-                    // available from the dependency provider.
+                    // Queue requesting the dependencies of the candidates as well if they are
+                    // cheaply available from the dependency provider.
                     for &candidate in candidates {
                         if seen.insert(candidate)
                             && self.cache.are_dependencies_available_for(candidate)
@@ -529,23 +538,25 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
 
     /// Run the CDCL algorithm to solve the SAT problem
     ///
-    /// The CDCL algorithm's job is to find a valid assignment to the variables involved in the
-    /// provided clauses. It works in the following steps:
+    /// The CDCL algorithm's job is to find a valid assignment to the variables
+    /// involved in the provided clauses. It works in the following steps:
     ///
-    /// 1. __Set__: Assign a value to a variable that hasn't been assigned yet. An assignment in
-    ///    this step starts a new "level" (the first one being level 1). If all variables have been
-    ///    assigned, then we are done.
-    /// 2. __Propagate__: Perform [unit
-    ///    propagation](https://en.wikipedia.org/wiki/Unit_propagation). Assignments in this step
-    ///    are associated to the same "level" as the decision that triggered them. This "level"
-    ///    metadata is useful when it comes to handling conflicts. See [`Solver::propagate`] for the
+    /// 1. __Set__: Assign a value to a variable that hasn't been assigned yet.
+    ///    An assignment in this step starts a new "level" (the first one being
+    ///    level 1). If all variables have been assigned, then we are done.
+    /// 2. __Propagate__: Perform [unit propagation](https://en.wikipedia.org/wiki/Unit_propagation).
+    ///    Assignments in this step are associated to the same "level" as the
+    ///    decision that triggered them. This "level" metadata is useful when it
+    ///    comes to handling conflicts. See [`Solver::propagate`] for the
     ///    implementation of this step.
-    /// 3. __Learn__: If propagation finishes without conflicts, go back to 1. Otherwise find the
-    ///    combination of assignments that caused the conflict and add a new clause to the solver to
-    ///    forbid that combination of assignments (i.e. learn from this mistake so it is not
-    ///    repeated in the future). Then backtrack and go back to step 1 or, if the learnt clause is
-    ///    in conflict with existing clauses, declare the problem to be unsolvable. See
-    ///    [`Solver::analyze`] for the implementation of this step.
+    /// 3. __Learn__: If propagation finishes without conflicts, go back to 1.
+    ///    Otherwise find the combination of assignments that caused the
+    ///    conflict and add a new clause to the solver to forbid that
+    ///    combination of assignments (i.e. learn from this mistake so it is not
+    ///    repeated in the future). Then backtrack and go back to step 1 or, if
+    ///    the learnt clause is in conflict with existing clauses, declare the
+    ///    problem to be unsolvable. See [`Solver::analyze`] for the
+    ///    implementation of this step.
     ///
     /// The solver loop can be found in [`Solver::resolve_dependencies`].
     fn run_sat(&mut self) -> Result<(), UnsolvableOrCancelled> {
@@ -553,15 +564,16 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
         let mut level = 0;
 
         loop {
-            // A level of 0 means the decision loop has been completely reset because a partial
-            // solution was invalidated by newly added clauses.
+            // A level of 0 means the decision loop has been completely reset because a
+            // partial solution was invalidated by newly added clauses.
             if level == 0 {
                 // Level 1 is the initial decision level
                 level = 1;
 
-                // Assign `true` to the root solvable. This must be installed to satisfy the solution.
-                // The root solvable contains the dependencies that were injected when calling
-                // `Solver::solve`. If we can find a solution were the root is installable we found a
+                // Assign `true` to the root solvable. This must be installed to satisfy the
+                // solution. The root solvable contains the dependencies that
+                // were injected when calling `Solver::solve`. If we can find a
+                // solution were the root is installable we found a
                 // solution that satisfies the user requirements.
                 tracing::info!(
                     "╤══ install {} at level {level}",
@@ -612,15 +624,16 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
                 }
             }
 
-            // Enter the solver loop, return immediately if no new assignments have been made.
+            // Enter the solver loop, return immediately if no new assignments have been
+            // made.
             level = self.resolve_dependencies(level)?;
 
-            // We have a partial solution. E.g. there is a solution that satisfies all the clauses
-            // that have been added so far.
+            // We have a partial solution. E.g. there is a solution that satisfies all the
+            // clauses that have been added so far.
 
-            // Determine which solvables are part of the solution for which we did not yet get any
-            // dependencies. If we find any such solvable it means we did not arrive at the full
-            // solution yet.
+            // Determine which solvables are part of the solution for which we did not yet
+            // get any dependencies. If we find any such solvable it means we
+            // did not arrive at the full solution yet.
             let new_solvables: Vec<_> = self
                 .decision_tracker
                 .stack()
@@ -696,16 +709,19 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
 
     /// Resolves all dependencies
     ///
-    /// Repeatedly chooses the next variable to assign, and calls [`Solver::set_propagate_learn`] to
-    /// drive the solving process (as you can see from the name, the method executes the set,
-    /// propagate and learn steps described in the [`Solver::run_sat`] docs).
+    /// Repeatedly chooses the next variable to assign, and calls
+    /// [`Solver::set_propagate_learn`] to drive the solving process (as you
+    /// can see from the name, the method executes the set, propagate and
+    /// learn steps described in the [`Solver::run_sat`] docs).
     ///
-    /// The next variable to assign is obtained by finding the next dependency for which no concrete
-    /// package has been picked yet. Then we pick the highest possible version for that package, or
-    /// the favored version if it was provided by the user, and set its value to true.
+    /// The next variable to assign is obtained by finding the next dependency
+    /// for which no concrete package has been picked yet. Then we pick the
+    /// highest possible version for that package, or the favored version if
+    /// it was provided by the user, and set its value to true.
     fn resolve_dependencies(&mut self, mut level: u32) -> Result<u32, UnsolvableOrCancelled> {
         loop {
-            // Make a decision. If no decision could be made it means the problem is satisfyable.
+            // Make a decision. If no decision could be made it means the problem is
+            // satisfyable.
             let Some((candidate, required_by, clause_id)) = self.decide() else {
                 break;
             };
@@ -718,10 +734,12 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
         Ok(level)
     }
 
-    /// Pick a solvable that we are going to assign true. This function uses a heuristic to
-    /// determine to best decision to make. The function selects the requirement that has the least
-    /// amount of working available candidates and selects the best candidate from that list. This
-    /// ensures that if there are conflicts they are delt with as early as possible.
+    /// Pick a solvable that we are going to assign true. This function uses a
+    /// heuristic to determine to best decision to make. The function
+    /// selects the requirement that has the least amount of working
+    /// available candidates and selects the best candidate from that list. This
+    /// ensures that if there are conflicts they are delt with as early as
+    /// possible.
     fn decide(&mut self) -> Option<(SolvableId, SolvableId, ClauseId)> {
         let mut best_decision = None;
         for &(solvable_id, deps, clause_id) in &self.requires_clauses {
@@ -733,8 +751,9 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
             // Consider only clauses in which no candidates have been installed
             let candidates = &self.cache.version_set_to_sorted_candidates[&deps];
 
-            // Either find the first assignable candidate or determine that one of the candidates is
-            // already assigned in which case the clause has already been satisfied.
+            // Either find the first assignable candidate or determine that one of the
+            // candidates is already assigned in which case the clause has
+            // already been satisfied.
             let candidate = candidates.iter().try_fold(
                 (None, 0),
                 |(first_selectable_candidate, selectable_candidates), &candidate| {
@@ -784,15 +803,18 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
 
     /// Executes one iteration of the CDCL loop
     ///
-    /// A set-propagate-learn round is always initiated by a requirement clause (i.e.
-    /// [`Clause::Requires`]). The parameters include the variable associated to the candidate for the
-    /// dependency (`solvable`), the package that originates the dependency (`required_by`), and the
+    /// A set-propagate-learn round is always initiated by a requirement clause
+    /// (i.e. [`Clause::Requires`]). The parameters include the variable
+    /// associated to the candidate for the dependency (`solvable`), the
+    /// package that originates the dependency (`required_by`), and the
     /// id of the requires clause (`clause_id`).
     ///
-    /// Refer to the documentation of [`Solver::run_sat`] for details on the CDCL algorithm.
+    /// Refer to the documentation of [`Solver::run_sat`] for details on the
+    /// CDCL algorithm.
     ///
-    /// Returns the new level after this set-propagate-learn round, or a [`Problem`] if we
-    /// discovered that the requested jobs are unsatisfiable.
+    /// Returns the new level after this set-propagate-learn round, or a
+    /// [`Problem`] if we discovered that the requested jobs are
+    /// unsatisfiable.
     fn set_propagate_learn(
         &mut self,
         mut level: u32,
@@ -901,7 +923,8 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
 
         tracing::debug!("├─ Backtracked to level {level}");
 
-        // Optimization: propagate right now, since we know that the clause is a unit clause
+        // Optimization: propagate right now, since we know that the clause is a unit
+        // clause
         let decision = literal.satisfying_value();
         self.decision_tracker
             .try_add_decision(
@@ -919,18 +942,20 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
 
     /// The propagate step of the CDCL algorithm
     ///
-    /// Propagation is implemented by means of watches: each clause that has two or more literals is
-    /// "subscribed" to changes in the values of two solvables that appear in the clause. When a value
-    /// is assigned to a solvable, each of the clauses tracking that solvable will be notified. That
-    /// way, the clause can check whether the literal that is using the solvable has become false, in
-    /// which case it picks a new solvable to watch (if available) or triggers an assignment.
+    /// Propagation is implemented by means of watches: each clause that has two
+    /// or more literals is "subscribed" to changes in the values of two
+    /// solvables that appear in the clause. When a value is assigned to a
+    /// solvable, each of the clauses tracking that solvable will be notified.
+    /// That way, the clause can check whether the literal that is using the
+    /// solvable has become false, in which case it picks a new solvable to
+    /// watch (if available) or triggers an assignment.
     fn propagate(&mut self, level: u32) -> Result<(), PropagationError> {
         if let Some(value) = self.cache.provider.should_cancel_with_value() {
             return Err(PropagationError::Cancelled(value));
         };
 
-        // Negative assertions derived from other rules (assertions are clauses that consist of a
-        // single literal, and therefore do not have watches)
+        // Negative assertions derived from other rules (assertions are clauses that
+        // consist of a single literal, and therefore do not have watches)
         for &(solvable_id, clause_id) in &self.negative_assertions {
             let value = false;
             let decided = self
@@ -988,7 +1013,8 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
         while let Some(decision) = self.decision_tracker.next_unpropagated() {
             let pkg = decision.solvable_id;
 
-            // Propagate, iterating through the linked list of clauses that watch this solvable
+            // Propagate, iterating through the linked list of clauses that watch this
+            // solvable
             let mut old_predecessor_clause_id: Option<ClauseId>;
             let mut predecessor_clause_id: Option<ClauseId> = None;
             let mut clause_id = self.watches.first_clause_watching_solvable(pkg);
@@ -1094,8 +1120,8 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
 
     /// Adds the clause with `clause_id` to the current `Problem`
     ///
-    /// Because learnt clauses are not relevant for the user, they are not added to the `Problem`.
-    /// Instead, we report the clauses that caused them.
+    /// Because learnt clauses are not relevant for the user, they are not added
+    /// to the `Problem`. Instead, we report the clauses that caused them.
     fn analyze_unsolvable_clause(
         clauses: &Arena<ClauseId, ClauseState>,
         learnt_why: &Mapping<LearntClauseId, Vec<ClauseId>>,
@@ -1121,7 +1147,8 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
         }
     }
 
-    /// Create a [`Problem`] based on the id of the clause that triggered an unrecoverable conflict
+    /// Create a [`Problem`] based on the id of the clause that triggered an
+    /// unrecoverable conflict
     fn analyze_unsolvable(&mut self, clause_id: ClauseId) -> Problem {
         let last_decision = self.decision_tracker.stack().last().unwrap();
         let highest_level = self.decision_tracker.level(last_decision.solvable_id);
@@ -1188,14 +1215,16 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
 
     /// Analyze the causes of the conflict and learn from it
     ///
-    /// This function finds the combination of assignments that caused the conflict and adds a new
-    /// clause to the solver to forbid that combination of assignments (i.e. learn from this mistake
-    /// so it is not repeated in the future). It corresponds to the `Solver.analyze` function from
-    /// the MiniSAT paper.
+    /// This function finds the combination of assignments that caused the
+    /// conflict and adds a new clause to the solver to forbid that
+    /// combination of assignments (i.e. learn from this mistake
+    /// so it is not repeated in the future). It corresponds to the
+    /// `Solver.analyze` function from the MiniSAT paper.
     ///
-    /// Returns the level to which we should backtrack, the id of the learnt clause and the literal
-    /// that should be assigned (by definition, when we learn a clause, all its literals except one
-    /// evaluate to false, so the value of the remaining literal must be assigned to make the clause
+    /// Returns the level to which we should backtrack, the id of the learnt
+    /// clause and the literal that should be assigned (by definition, when
+    /// we learn a clause, all its literals except one evaluate to false, so
+    /// the value of the remaining literal must be assigned to make the clause
     /// become true)
     fn analyze(
         &mut self,
@@ -1260,8 +1289,8 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>, RT:
 
                 current_level = last_decision_level;
 
-                // We are interested in the first literal we come across that caused the conflicting
-                // assignment
+                // We are interested in the first literal we come across that caused the
+                // conflicting assignment
                 if seen.contains(&last_decision.solvable_id) {
                     break;
                 }

--- a/tests/solver.rs
+++ b/tests/solver.rs
@@ -1,3 +1,19 @@
+use std::{
+    any::Any,
+    cell::{Cell, RefCell},
+    collections::{HashMap, HashSet},
+    fmt::{Debug, Display, Formatter},
+    io::{stderr, Write},
+    num::ParseIntError,
+    rc::Rc,
+    str::FromStr,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
 use indexmap::IndexMap;
 use itertools::Itertools;
 use resolvo::{
@@ -5,38 +21,27 @@ use resolvo::{
     KnownDependencies, NameId, Pool, SolvableId, Solver, SolverCache, UnsolvableOrCancelled,
     VersionSet, VersionSetId,
 };
-use std::cell::RefCell;
-use std::collections::HashSet;
-use std::rc::Rc;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
-use std::{
-    any::Any,
-    cell::Cell,
-    collections::HashMap,
-    fmt::{Debug, Display, Formatter},
-    io::stderr,
-    io::Write,
-    num::ParseIntError,
-    str::FromStr,
-};
 use tracing_test::traced_test;
 
 // Let's define our own packaging version system and dependency specification.
-// This is a very simple version system, where a package is identified by a name and a version
-// in which the version is just an integer. The version is a range so can be noted as 0..2
-// or something of the sorts, we also support constrains which means it should not use that
-// package version this is also represented with a range.
+// This is a very simple version system, where a package is identified by a name
+// and a version in which the version is just an integer. The version is a range
+// so can be noted as 0..2 or something of the sorts, we also support constrains
+// which means it should not use that package version this is also represented
+// with a range.
 //
-// You can also use just a single number for a range like `package 0` which means the range from 0..1 (excluding the end)
+// You can also use just a single number for a range like `package 0` which
+// means the range from 0..1 (excluding the end)
 //
-// Lets call the tuples of (Name, Version) a `Pack` and the tuples of (Name, Range<u32>) a `Spec`
+// Lets call the tuples of (Name, Version) a `Pack` and the tuples of (Name,
+// Range<u32>) a `Spec`
 //
-// We also need to create a custom provider that tells us how to sort the candidates. This is unique to each
-// packaging ecosystem. Let's call our ecosystem 'BundleBox' so that how we call the provider as well.
+// We also need to create a custom provider that tells us how to sort the
+// candidates. This is unique to each packaging ecosystem. Let's call our
+// ecosystem 'BundleBox' so that how we call the provider as well.
 
-/// This is `Pack` which is a unique version and name in our bespoke packaging system
+/// This is `Pack` which is a unique version and name in our bespoke packaging
+/// system
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone, Hash)]
 struct Pack {
     version: u32,
@@ -96,7 +101,8 @@ impl FromStr for Pack {
     }
 }
 
-/// We can use this to see if a `Pack` is contained in a range of package versions or a `Spec`
+/// We can use this to see if a `Pack` is contained in a range of package
+/// versions or a `Spec`
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct Spec {
     name: String,
@@ -156,7 +162,8 @@ struct BundleBoxProvider {
     concurrent_requests_max: Rc<Cell<usize>>,
     sleep_before_return: bool,
 
-    // A mapping of packages that we have requested candidates for. This way we can keep track of duplicate requests.
+    // A mapping of packages that we have requested candidates for. This way we can keep track of
+    // duplicate requests.
     requested_candidates: RefCell<HashSet<NameId>>,
     requested_dependencies: RefCell<HashSet<SolvableId>>,
 }
@@ -239,8 +246,9 @@ impl BundleBoxProvider {
             );
     }
 
-    // Sends a value from the dependency provider to the solver, introducing a minimal delay to force
-    // concurrency to be used (unless there is no async runtime available)
+    // Sends a value from the dependency provider to the solver, introducing a
+    // minimal delay to force concurrency to be used (unless there is no async
+    // runtime available)
     async fn maybe_delay<T: Send + 'static>(&self, value: T) -> T {
         if self.sleep_before_return {
             tokio::time::sleep(Duration::from_millis(10)).await;
@@ -405,7 +413,7 @@ fn solve_unsat(provider: BundleBoxProvider, specs: &[&str]) -> String {
     let requirements = provider.requirements(specs);
     let pool = provider.pool();
     let mut solver = Solver::new(provider);
-    match solver.solve(requirements) {
+    match solver.solve(requirements, Vec::new()) {
         Ok(_) => panic!("expected unsat, but a solution was found"),
         Err(UnsolvableOrCancelled::Unsolvable(problem)) => {
             // Write the problem graphviz to stderr
@@ -424,7 +432,8 @@ fn solve_unsat(provider: BundleBoxProvider, specs: &[&str]) -> String {
     }
 }
 
-/// Solve the problem and returns either a solution represented as a string or an error string.
+/// Solve the problem and returns either a solution represented as a string or
+/// an error string.
 fn solve_snapshot(mut provider: BundleBoxProvider, specs: &[&str]) -> String {
     // The test dependency provider requires time support for sleeping
     let runtime = tokio::runtime::Builder::new_current_thread()
@@ -437,7 +446,7 @@ fn solve_snapshot(mut provider: BundleBoxProvider, specs: &[&str]) -> String {
     let requirements = provider.requirements(specs);
     let pool = provider.pool();
     let mut solver = Solver::new(provider).with_runtime(runtime);
-    match solver.solve(requirements) {
+    match solver.solve(requirements, Vec::new()) {
         Ok(solvables) => transaction_to_string(&pool, &solvables),
         Err(UnsolvableOrCancelled::Unsolvable(problem)) => {
             // Write the problem graphviz to stderr
@@ -463,7 +472,7 @@ fn test_unit_propagation_1() {
     let root_requirements = provider.requirements(&["asdf"]);
     let pool = provider.pool();
     let mut solver = Solver::new(provider);
-    let solved = solver.solve(root_requirements).unwrap();
+    let solved = solver.solve(root_requirements, Vec::new()).unwrap();
 
     assert_eq!(solved.len(), 1);
     let solvable = pool.resolve_solvable(solved[0]);
@@ -483,7 +492,7 @@ fn test_unit_propagation_nested() {
     let requirements = provider.requirements(&["asdf"]);
     let pool = provider.pool();
     let mut solver = Solver::new(provider);
-    let solved = solver.solve(requirements).unwrap();
+    let solved = solver.solve(requirements, Vec::new()).unwrap();
 
     assert_eq!(solved.len(), 2);
 
@@ -510,7 +519,7 @@ fn test_resolve_multiple() {
     let requirements = provider.requirements(&["asdf", "efgh"]);
     let pool = provider.pool();
     let mut solver = Solver::new(provider);
-    let solved = solver.solve(requirements).unwrap();
+    let solved = solver.solve(requirements, Vec::new()).unwrap();
 
     assert_eq!(solved.len(), 2);
 
@@ -568,7 +577,7 @@ fn test_resolve_with_nonexisting() {
     let requirements = provider.requirements(&["asdf"]);
     let pool = provider.pool();
     let mut solver = Solver::new(provider);
-    let solved = solver.solve(requirements).unwrap();
+    let solved = solver.solve(requirements, Vec::new()).unwrap();
 
     assert_eq!(solved.len(), 1);
 
@@ -602,7 +611,7 @@ fn test_resolve_with_nested_deps() {
     let requirements = provider.requirements(&["apache-airflow"]);
     let pool = provider.pool();
     let mut solver = Solver::new(provider);
-    let solved = solver.solve(requirements).unwrap();
+    let solved = solver.solve(requirements, Vec::new()).unwrap();
 
     assert_eq!(solved.len(), 1);
 
@@ -629,7 +638,7 @@ fn test_resolve_with_unknown_deps() {
     let requirements = provider.requirements(&["opentelemetry-api"]);
     let pool = provider.pool();
     let mut solver = Solver::new(provider);
-    let solved = solver.solve(requirements).unwrap();
+    let solved = solver.solve(requirements, Vec::new()).unwrap();
 
     assert_eq!(solved.len(), 1);
 
@@ -662,8 +671,8 @@ fn test_resolve_and_cancel() {
     insta::assert_snapshot!(error);
 }
 
-/// Locking a specific package version in this case a lower version namely `3` should result
-/// in the higher package not being considered
+/// Locking a specific package version in this case a lower version namely `3`
+/// should result in the higher package not being considered
 #[test]
 fn test_resolve_locked_top_level() {
     let mut provider =
@@ -674,14 +683,15 @@ fn test_resolve_locked_top_level() {
 
     let pool = provider.pool();
     let mut solver = Solver::new(provider);
-    let solved = solver.solve(requirements).unwrap();
+    let solved = solver.solve(requirements, Vec::new()).unwrap();
 
     assert_eq!(solved.len(), 1);
     let solvable_id = solved[0];
     assert_eq!(pool.resolve_solvable(solvable_id).inner().version, 3);
 }
 
-/// Should ignore lock when it is not a top level package and a newer version exists without it
+/// Should ignore lock when it is not a top level package and a newer version
+/// exists without it
 #[test]
 fn test_resolve_ignored_locked_top_level() {
     let mut provider = BundleBoxProvider::from_packages(&[
@@ -695,7 +705,7 @@ fn test_resolve_ignored_locked_top_level() {
     let requirements = provider.requirements(&["asdf"]);
     let pool = provider.pool();
     let mut solver = Solver::new(provider);
-    let solved = solver.solve(requirements).unwrap();
+    let solved = solver.solve(requirements, Vec::new()).unwrap();
 
     assert_eq!(solved.len(), 1);
     let solvable = pool.resolve_solvable(solved[0]);
@@ -753,7 +763,7 @@ fn test_resolve_cyclic() {
     let requirements = provider.requirements(&["a 0..100"]);
     let pool = provider.pool();
     let mut solver = Solver::new(provider);
-    let solved = solver.solve(requirements).unwrap();
+    let solved = solver.solve(requirements, Vec::new()).unwrap();
 
     let result = transaction_to_string(&pool, &solved);
     insta::assert_snapshot!(result, @r###"
@@ -1001,4 +1011,25 @@ fn test_root_excluded() {
     let mut provider = BundleBoxProvider::from_packages(&[("a", 1, vec![])]);
     provider.exclude("a", 1, "it is externally excluded");
     insta::assert_snapshot!(solve_snapshot(provider, &["a"]));
+}
+
+#[test]
+fn test_constraints() {
+    let provider = BundleBoxProvider::from_packages(&[
+        ("a", 1, vec!["b 0..10"]),
+        ("b", 1, vec![]),
+        ("b", 2, vec![]),
+        ("c", 1, vec![]),
+    ]);
+    let requirements = provider.requirements(&["a 0..10"]);
+    let constraints = provider.requirements(&["b 1..2", "c"]);
+    let pool = provider.pool();
+    let mut solver = Solver::new(provider);
+    let solved = solver.solve(requirements, constraints).unwrap();
+
+    let result = transaction_to_string(&pool, &solved);
+    insta::assert_snapshot!(result, @r###"
+        a=1
+        b=1
+        "###);
 }


### PR DESCRIPTION
This adds `constraints` to the root solvable which allows imposing constraints on the solution for packages that are not necessarily part of the solution.

The behavior for this already existed, it just wasn't exposed in the API.