### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/mamba-org/resolvo/compare/v0.4.1...v0.5.0) - 2024-06-03
+
+### Added
+- root constraints ([#38](https://github.com/mamba-org/resolvo/pull/38))
+
+### Other
+- small memory performance optimizations ([#35](https://github.com/mamba-org/resolvo/pull/35))
+
 ## [0.4.1](https://github.com/mamba-org/resolvo/compare/v0.4.0...v0.4.1) - 2024-05-22
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resolvo"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Adolfo Ochagavía <github@adolfo.ochagavia.nl>", "Bas Zalmstra <zalmstra.bas@gmail.com>", "Tim de Jager <tdejager89@gmail.com>"]
 description = "Fast package resolver written in Rust (CDCL based SAT solving)"
 keywords = ["dependency", "solver", "version"]


### PR DESCRIPTION
## 🤖 New release
* `resolvo`: 0.4.1 -> 0.5.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/mamba-org/resolvo/compare/v0.4.1...v0.5.0) - 2024-06-03

### Added
- root constraints ([#38](https://github.com/mamba-org/resolvo/pull/38))

### Other
- small memory performance optimizations ([#35](https://github.com/mamba-org/resolvo/pull/35))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).