### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/mamba-org/resolvo/compare/resolvo-v0.6.1...resolvo-v0.6.2) - 2024-06-11
+
+### Added
+- release-plz resolvo_cpp
+- add rattler-build recipe ([#47](https://github.com/mamba-org/resolvo/pull/47))
+- c++ bindings ([#41](https://github.com/mamba-org/resolvo/pull/41))
+
 ## [0.6.1](https://github.com/mamba-org/resolvo/compare/resolvo-v0.6.0...resolvo-v0.6.1) - 2024-06-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,7 +1153,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "resolvo"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "ahash",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cpp", "tools/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Adolfo Ochagavía <github@adolfo.ochagavia.nl>", "Bas Zalmstra <zalmstra.bas@gmail.com>", "Tim de Jager <tdejager89@gmail.com>"]
 homepage = "https://github.com/mamba-org/resolvo"
 repository = "https://github.com/mamba-org/resolvo"

--- a/cpp/CHANGELOG.md
+++ b/cpp/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/mamba-org/resolvo/releases/tag/resolvo_cpp-v0.1.0) - 2024-06-11
+
+### Added
+- release-plz resolvo_cpp
+- add rattler-build recipe ([#47](https://github.com/mamba-org/resolvo/pull/47))
+- c++ bindings ([#41](https://github.com/mamba-org/resolvo/pull/41))
+- update README example and capabilities
+- resolvo banner
+- license, ci, readme
+
+### Fixed
+- readme link
+- typos
+- build badge
+
+### Other
+- add projects using resolvo
+- Show the docs badge ([#12](https://github.com/mamba-org/resolvo/pull/12))
+- update banner
+- add crates badge
+- break out tests to integration test

--- a/cpp/CHANGELOG.md
+++ b/cpp/CHANGELOG.md
@@ -9,21 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0](https://github.com/mamba-org/resolvo/releases/tag/resolvo_cpp-v0.1.0) - 2024-06-11
 
 ### Added
-- release-plz resolvo_cpp
-- add rattler-build recipe ([#47](https://github.com/mamba-org/resolvo/pull/47))
 - c++ bindings ([#41](https://github.com/mamba-org/resolvo/pull/41))
-- update README example and capabilities
-- resolvo banner
-- license, ci, readme
-
-### Fixed
-- readme link
-- typos
-- build badge
-
-### Other
-- add projects using resolvo
-- Show the docs badge ([#12](https://github.com/mamba-org/resolvo/pull/12))
-- update banner
-- add crates badge
-- break out tests to integration test

--- a/cpp/Cargo.toml
+++ b/cpp/Cargo.toml
@@ -15,7 +15,7 @@ readme.workspace = true
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
-resolvo = { version = "0.6.1", path = "../" }
+resolvo = { version = "0.6.2", path = "../" }
 
 [build-dependencies]
 anyhow = "1"


### PR DESCRIPTION
## 🤖 New release
* `resolvo_cpp`: 0.1.0
* `resolvo`: 0.6.1 -> 0.6.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `resolvo_cpp`
<blockquote>

## [0.1.0](https://github.com/mamba-org/resolvo/releases/tag/resolvo_cpp-v0.1.0) - 2024-06-11

### Added
- release-plz resolvo_cpp
- add rattler-build recipe ([#47](https://github.com/mamba-org/resolvo/pull/47))
- c++ bindings ([#41](https://github.com/mamba-org/resolvo/pull/41))
- update README example and capabilities
- resolvo banner
- license, ci, readme

### Fixed
- readme link
- typos
- build badge

### Other
- add projects using resolvo
- Show the docs badge ([#12](https://github.com/mamba-org/resolvo/pull/12))
- update banner
- add crates badge
- break out tests to integration test
</blockquote>

## `resolvo`
<blockquote>

## [0.6.2](https://github.com/mamba-org/resolvo/compare/resolvo-v0.6.1...resolvo-v0.6.2) - 2024-06-11

### Added
- release-plz resolvo_cpp
- add rattler-build recipe ([#47](https://github.com/mamba-org/resolvo/pull/47))
- c++ bindings ([#41](https://github.com/mamba-org/resolvo/pull/41))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).