### PR TITLE
fix: display_merged_solvables to display merged solvables correctly

### DIFF
--- a/cpp/tests/solve.cpp
+++ b/cpp/tests/solve.cpp
@@ -73,12 +73,13 @@ struct PackageDatabase : public resolvo::DependencyProvider {
         }
 
         std::stringstream ss;
-        ss << names[candidates[solvables[0].id].name];
+        ss << names[candidates[solvables[0].id].name] << " ";
 
         bool first = true;
         for (const auto& solvable : solvables) {
             if (!first) {
                 ss << " | ";
+            } else {
                 first = false;
             }
 


### PR DESCRIPTION
minor fix in display_merged_solvables so that it displays them correctly. without this fix a merged solvable is displayed as "a21" as opposed to "a 2 | 1".