### PR TITLE
fix: Add a virtual destructor to `DependencyProvider`

### DIFF
--- a/cpp/include/resolvo_dependency_provider.h
+++ b/cpp/include/resolvo_dependency_provider.h
@@ -18,6 +18,9 @@ using cbindgen_private::VersionSetId;
  * An interface that implements ecosystem specific logic.
  */
 struct DependencyProvider {
+
+    virtual ~DependencyProvider() = default;
+
     /**
      * Returns a user-friendly string representation of the specified solvable.
      *

--- a/cpp/include/resolvo_dependency_provider.h
+++ b/cpp/include/resolvo_dependency_provider.h
@@ -18,7 +18,6 @@ using cbindgen_private::VersionSetId;
  * An interface that implements ecosystem specific logic.
  */
 struct DependencyProvider {
-
     virtual ~DependencyProvider() = default;
 
     /**

--- a/cpp/tests/solve.cpp
+++ b/cpp/tests/solve.cpp
@@ -167,6 +167,11 @@ SCENARIO("Solve") {
     /// Construct a database with packages a, b, and c.
     PackageDatabase db;
 
+    // Check that PackageDatabase correctly implements the DependencyProvider interface
+    static_assert(std::has_virtual_destructor_v<PackageDatabase>);
+    static_assert(std::is_polymorphic_v<PackageDatabase>);
+    static_assert(std::is_base_of_v<resolvo::DependencyProvider, PackageDatabase>);
+
     auto a_1 = db.alloc_candidate("a", 1, {{db.alloc_requirement("b", 1, 4)}, {}});
     auto a_2 = db.alloc_candidate("a", 2, {{db.alloc_requirement("b", 1, 4)}, {}});
     auto a_3 = db.alloc_candidate("a", 3, {{db.alloc_requirement("b", 4, 7)}, {}});


### PR DESCRIPTION
When subclassing `DependencyProvider`, I currently get this warning:

```
warning: base class 'struct resolvo::DependencyProvider' has accessible non-virtual destructor [-Wnon-virtual-dtor]
   53 | struct PackageDatabase : public DependencyProvider {
      |        ^~~~~~~~~~~~~~~
```

I think any base class which has at least one virtual function, must have virtual destructor to respect class polymorphism.