### PR TITLE
feat(solver)!: Solve for optional solvables in addition to the root solvable

### DIFF
--- a/cpp/include/resolvo.h
+++ b/cpp/include/resolvo.h
@@ -4,6 +4,7 @@
 #include "resolvo_internal.h"
 
 namespace resolvo {
+using cbindgen_private::Problem;
 using cbindgen_private::Requirement;
 
 /**
@@ -30,8 +31,8 @@ inline Requirement requirement_union(VersionSetUnionId id) {
  * stored in `result`. If the solve was unsuccesfull an error describing the reason is returned and
  * the result vector will be empty.
  */
-inline String solve(DependencyProvider &provider, Slice<Requirement> requirements,
-                    Slice<VersionSetId> constraints, Vector<SolvableId> &result) {
+inline String solve(DependencyProvider &provider, const Problem &problem,
+                    Vector<SolvableId> &result) {
     cbindgen_private::DependencyProvider bridge{
         static_cast<void *>(&provider),
         private_api::bridge_display_solvable,
@@ -50,7 +51,7 @@ inline String solve(DependencyProvider &provider, Slice<Requirement> requirement
     };
 
     String error;
-    cbindgen_private::resolvo_solve(&bridge, requirements, constraints, &error, &result);
+    cbindgen_private::resolvo_solve(&bridge, &problem, &error, &result);
     return error;
 }
 }  // namespace resolvo

--- a/cpp/tests/solve.cpp
+++ b/cpp/tests/solve.cpp
@@ -216,19 +216,27 @@ SCENARIO("Solve") {
 
     auto c_1 = db.alloc_candidate("c", 1, {});
 
+    const auto d_1 = db.alloc_candidate("d", 1, {});
+
     // Construct a problem to be solved by the solver
     resolvo::Vector<resolvo::Requirement> requirements = {db.alloc_requirement("a", 1, 3)};
-    resolvo::Vector<resolvo::VersionSetId> constraints = {db.alloc_version_set("b", 1, 3),
-                                                          db.alloc_version_set("c", 1, 3)};
+    resolvo::Vector<resolvo::VersionSetId> constraints = {
+        db.alloc_version_set("b", 1, 3),
+        db.alloc_version_set("c", 1, 3),
+        db.alloc_version_set("d", 2, 2),
+    };
+    resolvo::Vector soft_requirements{c_1, d_1};
 
     // Solve the problem
     resolvo::Vector<resolvo::SolvableId> result;
-    resolvo::solve(db, requirements, constraints, result);
+    resolvo::Problem problem = {requirements, constraints, soft_requirements};
+    resolvo::solve(db, problem, result);
 
     // Check the result
-    REQUIRE(result.size() == 2);
+    REQUIRE(result.size() == 3);
     REQUIRE(result[0] == a_2);
     REQUIRE(result[1] == b_2);
+    REQUIRE(result[2] == c_1);
 }
 
 SCENARIO("Solve Union") {
@@ -264,7 +272,9 @@ SCENARIO("Solve Union") {
 
     // Solve the problem
     resolvo::Vector<resolvo::SolvableId> result;
-    resolvo::solve(db, requirements, constraints, result);
+    resolvo::Problem problem = {requirements, constraints, {}};
+    resolvo::solve(db, problem, result);
+    ;
 
     // Check the result
     REQUIRE(result.size() == 4);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@
 
 #![deny(missing_docs)]
 
+pub mod conflict;
 pub(crate) mod internal;
-pub mod problem;
 mod requirement;
 pub mod runtime;
 pub mod snapshot;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub use internal::{
 };
 use itertools::Itertools;
 pub use requirement::Requirement;
-pub use solver::{Solver, SolverCache, UnsolvableOrCancelled};
+pub use solver::{Problem, Solver, SolverCache, UnsolvableOrCancelled};
 
 /// An object that is used by the solver to query certain properties of
 /// different internalized objects.

--- a/src/solver/decision_tracker.rs
+++ b/src/solver/decision_tracker.rs
@@ -77,6 +77,11 @@ impl DecisionTracker {
     }
 
     pub(crate) fn undo_until(&mut self, level: u32) {
+        if level == 0 {
+            self.clear();
+            return;
+        }
+
         while let Some(decision) = self.stack.last() {
             if self.level(decision.solvable_id) <= level {
                 break;

--- a/src/solver/decision_tracker.rs
+++ b/src/solver/decision_tracker.rs
@@ -27,10 +27,6 @@ impl DecisionTracker {
         self.propagate_index = 0;
     }
 
-    pub(crate) fn is_empty(&self) -> bool {
-        self.stack.is_empty()
-    }
-
     pub(crate) fn assigned_value(&self, solvable_id: InternalSolvableId) -> Option<bool> {
         self.map.value(solvable_id)
     }

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -410,15 +410,6 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
                     let locked_solvable_id = package_candidates.locked;
                     let candidates = &package_candidates.candidates;
 
-                    // Check the assumption that no decision has been made about any of the
-                    // solvables.
-                    for &candidate in candidates {
-                        debug_assert!(
-                            self.decision_tracker.assigned_value(candidate.into()).is_none(),
-                            "a decision has been made about a candidate of a package that was not properly added yet."
-                        );
-                    }
-
                     // Each candidate gets a clause to disallow other candidates.
                     for (i, &candidate) in candidates.iter().enumerate() {
                         for &other_candidate in &candidates[i + 1..] {

--- a/tests/solver.rs
+++ b/tests/solver.rs
@@ -552,15 +552,15 @@ fn transaction_to_string(interner: &impl Interner, solvables: &Vec<SolvableId>) 
     buf
 }
 
-/// Unsat so that we can view the problem
+/// Unsat so that we can view the conflict
 fn solve_unsat(provider: BundleBoxProvider, specs: &[&str]) -> String {
     let requirements = provider.requirements(specs);
     let mut solver = Solver::new(provider);
     match solver.solve(requirements, Vec::new()) {
         Ok(_) => panic!("expected unsat, but a solution was found"),
-        Err(UnsolvableOrCancelled::Unsolvable(problem)) => {
-            // Write the problem graphviz to stderr
-            let graph = problem.graph(&solver);
+        Err(UnsolvableOrCancelled::Unsolvable(conflict)) => {
+            // Write the conflict graphviz to stderr
+            let graph = conflict.graph(&solver);
             let mut output = stderr();
             writeln!(output, "UNSOLVABLE:").unwrap();
             graph
@@ -569,7 +569,7 @@ fn solve_unsat(provider: BundleBoxProvider, specs: &[&str]) -> String {
             writeln!(output, "\n").unwrap();
 
             // Format a user friendly error message
-            problem.display_user_friendly(&solver).to_string()
+            conflict.display_user_friendly(&solver).to_string()
         }
         Err(UnsolvableOrCancelled::Cancelled(reason)) => *reason.downcast().unwrap(),
     }
@@ -590,9 +590,9 @@ fn solve_snapshot(mut provider: BundleBoxProvider, specs: &[&str]) -> String {
     let mut solver = Solver::new(provider).with_runtime(runtime);
     match solver.solve(requirements, Vec::new()) {
         Ok(solvables) => transaction_to_string(solver.provider(), &solvables),
-        Err(UnsolvableOrCancelled::Unsolvable(problem)) => {
-            // Write the problem graphviz to stderr
-            let graph = problem.graph(&solver);
+        Err(UnsolvableOrCancelled::Unsolvable(conflict)) => {
+            // Write the conflict graphviz to stderr
+            let graph = conflict.graph(&solver);
             let mut output = stderr();
             writeln!(output, "UNSOLVABLE:").unwrap();
             graph
@@ -601,7 +601,7 @@ fn solve_snapshot(mut provider: BundleBoxProvider, specs: &[&str]) -> String {
             writeln!(output, "\n").unwrap();
 
             // Format a user friendly error message
-            problem.display_user_friendly(&solver).to_string()
+            conflict.display_user_friendly(&solver).to_string()
         }
         Err(UnsolvableOrCancelled::Cancelled(reason)) => *reason.downcast().unwrap(),
     }
@@ -1355,9 +1355,9 @@ fn solve_for_snapshot(provider: SnapshotProvider, root_reqs: &[VersionSetId]) ->
         Vec::new(),
     ) {
         Ok(solvables) => transaction_to_string(solver.provider(), &solvables),
-        Err(UnsolvableOrCancelled::Unsolvable(problem)) => {
-            // Write the problem graphviz to stderr
-            let graph = problem.graph(&solver);
+        Err(UnsolvableOrCancelled::Unsolvable(conflict)) => {
+            // Write the conflict graphviz to stderr
+            let graph = conflict.graph(&solver);
             let mut output = stderr();
             writeln!(output, "UNSOLVABLE:").unwrap();
             graph
@@ -1366,7 +1366,7 @@ fn solve_for_snapshot(provider: SnapshotProvider, root_reqs: &[VersionSetId]) ->
             writeln!(output, "\n").unwrap();
 
             // Format a user friendly error message
-            problem.display_user_friendly(&solver).to_string()
+            conflict.display_user_friendly(&solver).to_string()
         }
         Err(UnsolvableOrCancelled::Cancelled(reason)) => *reason.downcast().unwrap(),
     }


### PR DESCRIPTION
Adds a new `Solver::solve_with_additional` method, that solves for the provided `root_requirements` and `root_constraints`, along with a set of additional (optional) solvables. Unless the corresponding package has been requested by a version set in another solvable's clauses, each additional solvable is _not_ subject to the package-level clauses introduced in `DependencyProvider::get_candidates` since the solvables have been requested specifically (and not through a version set).

This feature is useful for situations where you want to ensure that particular solvables (for example, previously installed solvables) are compatible with the solution to the root requirements and constraints.

The implementation is facilitated by making the `run_sat` method solve for arbitrary solvables at arbitrary levels, not just the root solvable. This allows the solver to solve for the additional solvables after solving for the root solvable while taking into account the clauses and decisions introduced in the solving process.

# Breaking changes
- Renames the `problem` module and its container structs to `conflict`, since they are used to inspect an unsatisfiable conflict
- Uses the newly added `solver::Problem` struct as an input for the `Solver::solve` method to allow for flexibility in solver input arguments

Existing users will have to change the code that calls `Solver::solve` to pass in an instance of the `Problem` struct rather than passing in the `root_requirements` and `root_constraints` directly as arguments to the method.