### PR TITLE
feat!: Version set unions as solvable requirements

### DIFF
--- a/cpp/include/resolvo.h
+++ b/cpp/include/resolvo.h
@@ -4,6 +4,24 @@
 #include "resolvo_internal.h"
 
 namespace resolvo {
+using cbindgen_private::Requirement;
+
+/**
+ * Specifies a requirement (dependency) of a single version set.
+ */
+inline Requirement requirement_single(VersionSetId id) {
+    return cbindgen_private::resolvo_requirement_single(id);
+}
+
+/**
+ * Specifies a requirement (dependency) of the union (logical OR) of multiple version sets.
+ * A solvable belonging to any of the version sets contained in the union satisfies the
+ * requirement. This variant is typically used for requirements that can be satisfied by two
+ * or more version sets belonging to different packages.
+ */
+inline Requirement requirement_union(VersionSetUnionId id) {
+    return cbindgen_private::resolvo_requirement_union(id);
+}
 
 /**
  * Called to solve a package problem.
@@ -12,7 +30,7 @@ namespace resolvo {
  * stored in `result`. If the solve was unsuccesfull an error describing the reason is returned and
  * the result vector will be empty.
  */
-inline String solve(DependencyProvider &provider, Slice<VersionSetId> requirements,
+inline String solve(DependencyProvider &provider, Slice<Requirement> requirements,
                     Slice<VersionSetId> constraints, Vector<SolvableId> &result) {
     cbindgen_private::DependencyProvider bridge{
         static_cast<void *>(&provider),
@@ -24,6 +42,7 @@ inline String solve(DependencyProvider &provider, Slice<VersionSetId> requiremen
         private_api::bridge_display_string,
         private_api::bridge_version_set_name,
         private_api::bridge_solvable_name,
+        private_api::bridge_version_sets_in_union,
         private_api::bridge_get_candidates,
         private_api::bridge_sort_candidates,
         private_api::bridge_filter_candidates,

--- a/cpp/include/resolvo_dependency_provider.h
+++ b/cpp/include/resolvo_dependency_provider.h
@@ -13,6 +13,7 @@ using cbindgen_private::NameId;
 using cbindgen_private::SolvableId;
 using cbindgen_private::StringId;
 using cbindgen_private::VersionSetId;
+using cbindgen_private::VersionSetUnionId;
 
 /**
  * An interface that implements ecosystem specific logic.
@@ -76,6 +77,11 @@ struct DependencyProvider {
     virtual NameId solvable_name(SolvableId solvable_id) = 0;
 
     /**
+     * Returns the version sets comprising the given union.
+     */
+    virtual Slice<VersionSetId> version_sets_in_union(VersionSetUnionId version_set_union_id) = 0;
+
+    /**
      * Obtains a list of solvables that should be considered when a package
      * with the given name is requested.
      */
@@ -131,6 +137,11 @@ extern "C" inline NameId bridge_version_set_name(void *data, VersionSetId versio
 }
 extern "C" inline NameId bridge_solvable_name(void *data, SolvableId solvable_id) {
     return reinterpret_cast<DependencyProvider *>(data)->solvable_name(solvable_id);
+}
+extern "C" inline Slice<VersionSetId> bridge_version_sets_in_union(
+    void *data, VersionSetUnionId version_set_union_id) {
+    return reinterpret_cast<DependencyProvider *>(data)->version_sets_in_union(
+        version_set_union_id);
 }
 
 extern "C" inline void bridge_get_candidates(void *data, NameId package, Candidates *result) {

--- a/cpp/include/resolvo_dependency_provider.h
+++ b/cpp/include/resolvo_dependency_provider.h
@@ -138,6 +138,10 @@ extern "C" inline NameId bridge_version_set_name(void *data, VersionSetId versio
 extern "C" inline NameId bridge_solvable_name(void *data, SolvableId solvable_id) {
     return reinterpret_cast<DependencyProvider *>(data)->solvable_name(solvable_id);
 }
+
+// HACK(clang): For some reason, clang needs this to know that the return type is complete
+static_assert(sizeof(Slice<VersionSetId>));
+
 extern "C" inline Slice<VersionSetId> bridge_version_sets_in_union(
     void *data, VersionSetUnionId version_set_union_id) {
     return reinterpret_cast<DependencyProvider *>(data)->version_sets_in_union(

--- a/cpp/src/lib.rs
+++ b/cpp/src/lib.rs
@@ -31,6 +31,66 @@ impl From<SolvableId> for resolvo::SolvableId {
     }
 }
 
+/// Specifies the dependency of a solvable on a set of version sets.
+/// cbindgen:derive-eq
+/// cbindgen:derive-neq
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub enum Requirement {
+    /// Specifies a dependency on a single version set.
+    /// cbindgen:derive-eq
+    /// cbindgen:derive-neq
+    Single(VersionSetId),
+    /// Specifies a dependency on the union (logical OR) of multiple version sets. A solvable
+    /// belonging to ANY of the version sets contained in the union satisfies the requirement.
+    /// This variant is typically used for requirements that can be satisfied by two or more
+    /// version sets belonging to different packages.
+    /// cbindgen:derive-eq
+    /// cbindgen:derive-neq
+    Union(VersionSetUnionId),
+}
+
+impl From<resolvo::Requirement> for crate::Requirement {
+    fn from(value: resolvo::Requirement) -> Self {
+        match value {
+            resolvo::Requirement::Single(id) => Requirement::Single(id.into()),
+            resolvo::Requirement::Union(id) => Requirement::Union(id.into()),
+        }
+    }
+}
+
+impl From<crate::Requirement> for resolvo::Requirement {
+    fn from(value: crate::Requirement) -> Self {
+        match value {
+            Requirement::Single(id) => resolvo::Requirement::Single(id.into()),
+            Requirement::Union(id) => resolvo::Requirement::Union(id.into()),
+        }
+    }
+}
+
+/// A unique identifier for a version set union. A version set union describes
+/// the union (logical OR) of a non-empty set of version sets belonging to
+/// more than one package.
+/// cbindgen:derive-eq
+/// cbindgen:derive-neq
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VersionSetUnionId {
+    id: u32,
+}
+
+impl From<resolvo::VersionSetUnionId> for crate::VersionSetUnionId {
+    fn from(id: resolvo::VersionSetUnionId) -> Self {
+        Self { id: id.0 }
+    }
+}
+
+impl From<crate::VersionSetUnionId> for resolvo::VersionSetUnionId {
+    fn from(id: crate::VersionSetUnionId) -> Self {
+        Self(id.id)
+    }
+}
+
 /// A unique identifier for a single version set. A version set describes a
 /// set of versions.
 /// cbindgen:derive-eq
@@ -102,7 +162,7 @@ pub struct Dependencies {
     /// A pointer to the first element of a list of requirements. Requirements
     /// defines which packages should be installed alongside the depending
     /// package and the constraints applied to the package.
-    pub requirements: Vector<VersionSetId>,
+    pub requirements: Vector<Requirement>,
 
     /// Defines additional constraints on packages that may or may not be part
     /// of the solution. Different from `requirements`, packages in this set
@@ -230,6 +290,12 @@ pub struct DependencyProvider {
     /// Returns the name of the package for the given solvable.
     pub solvable_name: unsafe extern "C" fn(data: *mut c_void, solvable_id: SolvableId) -> NameId,
 
+    /// Returns the version sets comprising the given union.
+    pub version_sets_in_union: unsafe extern "C" fn(
+        data: *mut c_void,
+        version_set_union_id: VersionSetUnionId,
+    ) -> Slice<'static, VersionSetId>,
+
     /// Obtains a list of solvables that should be considered when a package
     /// with the given name is requested.
     pub get_candidates:
@@ -313,6 +379,17 @@ impl<'d> resolvo::Interner for &'d DependencyProvider {
 
     fn solvable_name(&self, solvable: resolvo::SolvableId) -> resolvo::NameId {
         unsafe { (self.solvable_name)(self.data, solvable.into()) }.into()
+    }
+
+    fn version_sets_in_union(
+        &self,
+        version_set_union: resolvo::VersionSetUnionId,
+    ) -> impl Iterator<Item = resolvo::VersionSetId> {
+        unsafe { (self.version_sets_in_union)(self.data, version_set_union.into()) }
+            .as_slice()
+            .into_iter()
+            .copied()
+            .map(Into::into)
     }
 }
 
@@ -400,7 +477,7 @@ impl<'d> resolvo::DependencyProvider for &'d DependencyProvider {
 #[allow(unused)]
 pub extern "C" fn resolvo_solve(
     provider: &DependencyProvider,
-    requirements: Slice<VersionSetId>,
+    requirements: Slice<Requirement>,
     constraints: Slice<VersionSetId>,
     error: &mut String,
     result: &mut Vector<SolvableId>,
@@ -431,6 +508,20 @@ pub extern "C" fn resolvo_solve(
             false
         }
     }
+}
+
+#[no_mangle]
+#[allow(unused)]
+pub extern "C" fn resolvo_requirement_single(version_set_id: VersionSetId) -> Requirement {
+    Requirement::Single(version_set_id)
+}
+
+#[no_mangle]
+#[allow(unused)]
+pub extern "C" fn resolvo_requirement_union(
+    version_set_union_id: VersionSetUnionId,
+) -> Requirement {
+    Requirement::Union(version_set_union_id)
 }
 
 #[cfg(test)]

--- a/src/internal/id.rs
+++ b/src/internal/id.rs
@@ -53,6 +53,23 @@ impl ArenaId for VersionSetId {
     }
 }
 
+/// The id associated with a union (logical OR) of two or more version sets.
+#[repr(transparent)]
+#[derive(Clone, Default, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct VersionSetUnionId(pub u32);
+
+impl ArenaId for VersionSetUnionId {
+    fn from_usize(x: usize) -> Self {
+        Self(x as u32)
+    }
+
+    fn to_usize(self) -> usize {
+        self.0 as usize
+    }
+}
+
 /// The id associated to a solvable
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Ord, PartialOrd)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ pub struct KnownDependencies {
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
-    pub requirements: Vec<VersionSetId>,
+    pub requirements: Vec<Requirement>,
 
     /// Defines additional constraints on packages that may or may not be part
     /// of the solution. Different from `requirements`, packages in this set

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub(crate) mod internal;
 pub mod problem;
+mod requirement;
 pub mod runtime;
 pub mod snapshot;
 mod solver;
@@ -27,6 +28,7 @@ pub use internal::{
     mapping::Mapping,
 };
 use itertools::Itertools;
+pub use requirement::Requirement;
 pub use solver::{Solver, SolverCache, UnsolvableOrCancelled};
 
 /// An object that is used by the solver to query certain properties of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use std::{
 };
 
 pub use internal::{
-    id::{NameId, SolvableId, StringId, VersionSetId},
+    id::{NameId, SolvableId, StringId, VersionSetId, VersionSetUnionId},
     mapping::Mapping,
 };
 use itertools::Itertools;
@@ -87,6 +87,12 @@ pub trait Interner {
 
     /// Returns the name of the package for the given solvable.
     fn solvable_name(&self, solvable: SolvableId) -> NameId;
+
+    /// Returns the version sets comprising the given union.
+    fn version_sets_in_union(
+        &self,
+        version_set_union: VersionSetUnionId,
+    ) -> impl Iterator<Item = VersionSetId>;
 }
 
 /// Defines implementation specific behavior for the solver and a way for the

--- a/src/requirement.rs
+++ b/src/requirement.rs
@@ -45,11 +45,11 @@ impl Requirement {
         &'i self,
         interner: &'i impl Interner,
     ) -> impl Iterator<Item = VersionSetId> + 'i {
-        match self {
-            &Requirement::Single(version_set) => {
+        match *self {
+            Requirement::Single(version_set) => {
                 itertools::Either::Left(std::iter::once(version_set))
             }
-            &Requirement::Union(version_set_union) => {
+            Requirement::Union(version_set_union) => {
                 itertools::Either::Right(interner.version_sets_in_union(version_set_union))
             }
         }
@@ -63,15 +63,15 @@ pub(crate) struct DisplayRequirement<'i, I: Interner> {
 
 impl<'i, I: Interner> Display for DisplayRequirement<'i, I> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.requirement {
-            &Requirement::Single(version_set) => write!(
+        match *self.requirement {
+            Requirement::Single(version_set) => write!(
                 f,
                 "{} {}",
                 self.interner
                     .display_name(self.interner.version_set_name(version_set)),
                 self.interner.display_version_set(version_set)
             ),
-            &Requirement::Union(version_set_union) => {
+            Requirement::Union(version_set_union) => {
                 let formatted_version_sets = self
                     .interner
                     .version_sets_in_union(version_set_union)

--- a/src/requirement.rs
+++ b/src/requirement.rs
@@ -1,0 +1,91 @@
+use crate::{Interner, VersionSetId, VersionSetUnionId};
+use itertools::Itertools;
+use std::fmt::Display;
+
+/// Specifies the dependency of a solvable on a set of version sets.
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum Requirement {
+    /// Specifies a dependency on a single version set.
+    Single(VersionSetId),
+    /// Specifies a dependency on the union (logical OR) of multiple version sets. A solvable
+    /// belonging to _any_ of the version sets contained in the union satisfies the requirement.
+    /// This variant is typically used for requirements that can be satisfied by two or more
+    /// version sets belonging to _different_ packages.
+    Union(VersionSetUnionId),
+}
+
+impl Default for Requirement {
+    fn default() -> Self {
+        Self::Single(Default::default())
+    }
+}
+
+impl From<VersionSetId> for Requirement {
+    fn from(value: VersionSetId) -> Self {
+        Requirement::Single(value)
+    }
+}
+
+impl From<VersionSetUnionId> for Requirement {
+    fn from(value: VersionSetUnionId) -> Self {
+        Requirement::Union(value)
+    }
+}
+
+impl Requirement {
+    pub(crate) fn display<'i>(&'i self, interner: &'i impl Interner) -> impl Display + '_ {
+        DisplayRequirement {
+            interner,
+            requirement: self,
+        }
+    }
+
+    pub(crate) fn version_sets<'i>(
+        &'i self,
+        interner: &'i impl Interner,
+    ) -> impl Iterator<Item = VersionSetId> + 'i {
+        match self {
+            &Requirement::Single(version_set) => {
+                itertools::Either::Left(std::iter::once(version_set))
+            }
+            &Requirement::Union(version_set_union) => {
+                itertools::Either::Right(interner.version_sets_in_union(version_set_union))
+            }
+        }
+    }
+}
+
+pub(crate) struct DisplayRequirement<'i, I: Interner> {
+    interner: &'i I,
+    requirement: &'i Requirement,
+}
+
+impl<'i, I: Interner> Display for DisplayRequirement<'i, I> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.requirement {
+            &Requirement::Single(version_set) => write!(
+                f,
+                "{} {}",
+                self.interner
+                    .display_name(self.interner.version_set_name(version_set)),
+                self.interner.display_version_set(version_set)
+            ),
+            &Requirement::Union(version_set_union) => {
+                let formatted_version_sets = self
+                    .interner
+                    .version_sets_in_union(version_set_union)
+                    .format_with(" | ", |version_set, f| {
+                        f(&format_args!(
+                            "{} {}",
+                            self.interner
+                                .display_name(self.interner.version_set_name(version_set)),
+                            self.interner.display_version_set(version_set)
+                        ))
+                    });
+
+                write!(f, "{}", formatted_version_sets)
+            }
+        }
+    }
+}

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -16,7 +16,7 @@ use futures::FutureExt;
 
 use crate::{
     internal::arena::ArenaId, Candidates, Dependencies, DependencyProvider, Interner, Mapping,
-    NameId, SolvableId, SolverCache, StringId, VersionSetId,
+    NameId, SolvableId, SolverCache, StringId, VersionSetId, VersionSetUnionId,
 };
 
 /// A single solvable in a [`DependencySnapshot`].
@@ -395,6 +395,13 @@ impl<'s> Interner for SnapshotProvider<'s> {
 
     fn solvable_name(&self, solvable: SolvableId) -> NameId {
         self.solvable(solvable).name
+    }
+
+    fn version_sets_in_union(
+        &self,
+        _version_set_union: VersionSetUnionId,
+    ) -> impl Iterator<Item = VersionSetId> {
+        std::iter::empty()
     }
 }
 

--- a/src/solver/watch_map.rs
+++ b/src/solver/watch_map.rs
@@ -52,10 +52,7 @@ impl WatchMap {
         clause.watched_literals[watch_index] = new_watch;
         clause.link_to_clause(
             watch_index,
-            *self
-                .map
-                .get(new_watch)
-                .expect("linking to unknown solvable"),
+            self.map.get(new_watch).copied().unwrap_or(ClauseId::null()),
         );
         self.map.insert(new_watch, clause_id);
     }

--- a/tests/snapshots/solver__snapshot.snap
+++ b/tests/snapshots/solver__snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/solver.rs
-assertion_line: 1121
 expression: "solve_for_snapshot(snapshot_provider, &[menu_req])"
 ---
 dropdown=2

--- a/tests/snapshots/solver__snapshot_union_requirements.snap
+++ b/tests/snapshots/solver__snapshot_union_requirements.snap
@@ -1,0 +1,6 @@
+---
+source: tests/solver.rs
+expression: "solve_for_snapshot(snapshot_provider, &[intl_req, union_req])"
+---
+intl=5
+union=1

--- a/tests/solver.rs
+++ b/tests/solver.rs
@@ -22,7 +22,7 @@ use resolvo::{
     snapshot::{DependencySnapshot, SnapshotProvider},
     utils::{Pool, Range},
     Candidates, Dependencies, DependencyProvider, Interner, KnownDependencies, NameId, SolvableId,
-    Solver, SolverCache, StringId, UnsolvableOrCancelled, VersionSetId,
+    Solver, SolverCache, StringId, UnsolvableOrCancelled, VersionSetId, VersionSetUnionId,
 };
 use tracing_test::traced_test;
 
@@ -318,6 +318,13 @@ impl Interner for BundleBoxProvider {
 
     fn solvable_name(&self, solvable: SolvableId) -> NameId {
         self.pool.resolve_solvable(solvable).name
+    }
+
+    fn version_sets_in_union(
+        &self,
+        _version_set_union: VersionSetUnionId,
+    ) -> impl Iterator<Item = VersionSetId> {
+        std::iter::empty()
     }
 }
 

--- a/tools/solve-snapshot/src/main.rs
+++ b/tools/solve-snapshot/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
         let mut solver = Solver::new(provider);
         let mut records = None;
         let mut error = None;
-        match solver.solve(vec![package_requirement], vec![]) {
+        match solver.solve(vec![package_requirement.into()], vec![]) {
             Ok(solution) => {
                 eprintln!("OK");
                 records = Some(solution.len())


### PR DESCRIPTION
This PR introduces the concept of _version set unions_ and allows them to be used to specify solvable requirements that can be fulfilled by more than one version set (belonging to more than one package).

The change is facilitated by the introduction of a `Requirement` type, which is used instead of `VersionSetId`s to specify a required dependency of a solvable. A requirement can either be comprised of a single version set (a `VersionSetId`), or multiple version sets (a `VersionSetUnionId`). This allows existing code bases to continue using a single version set (`VersionSetId`) as a requirement specification without ever having to touch version set unions (`VersionSetUnionId`).

# Breaking changes
This PR introduces _breaking_ changes - the main ones being the following:

- Added the `Interner::version_sets_in_union` trait method 
- Changed the type of the `requirements` field of  `KnownDependencies` from `Vec<VersionSetId>` to `Vec<Requirement>`.
- Renamed the `requirements` field of `DependencySnapshot` to `version_sets`
- Added the `version_set_unions` field to `DependencySnapshot` (only affects those who are constructing `DependencySnapshot` instances manually)

## API migration
Migrating existing depending projects that do not rely on version set unions to the new API is quite straightforward.
- Add a placeholder implementation for `version_sets_in_union` in impls of `Interner`. It is perfectly fine for the implementation to be `unimplemented!`, since if version set unions are unused this method will never be called.
- Modify implementations of `DependencyProvider::get_dependencies` to convert the `VersionSetId`s used in the `requirements` field of  `KnownDependencies` to `Requirement`s. Since `Requirement` implements `From<VersionSetId>`, this is as simple as calling `From::from` or `Into::into` on each `VersionSetId`.
-  For those using `DependencySnapshot`, the `requirements` field has been renamed to `version_sets`; all other functionality remains the same.
