### PR TITLE
feat(solver)!: Make `Problem` use builder pattern

### DIFF
--- a/cpp/src/lib.rs
+++ b/cpp/src/lib.rs
@@ -490,26 +490,30 @@ pub extern "C" fn resolvo_solve(
 ) -> bool {
     let mut solver = resolvo::Solver::new(provider);
 
-    let problem = resolvo::Problem {
-        requirements: problem
-            .requirements
-            .into_iter()
-            .copied()
-            .map(Into::into)
-            .collect(),
-        constraints: problem
-            .constraints
-            .into_iter()
-            .copied()
-            .map(Into::into)
-            .collect(),
-        soft_requirements: problem
-            .soft_requirements
-            .into_iter()
-            .copied()
-            .map(Into::into)
-            .collect(),
-    };
+    let problem = resolvo::Problem::new()
+        .requirements(
+            problem
+                .requirements
+                .into_iter()
+                .copied()
+                .map(Into::into)
+                .collect(),
+        )
+        .constraints(
+            problem
+                .constraints
+                .into_iter()
+                .copied()
+                .map(Into::into)
+                .collect(),
+        )
+        .soft_requirements(
+            problem
+                .soft_requirements
+                .into_iter()
+                .copied()
+                .map(Into::into),
+        );
 
     match solver.solve(problem) {
         Ok(solution) => {

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -35,17 +35,60 @@ struct AddClauseOutput {
 }
 
 /// Describes the problem that is to be solved by the solver.
-#[derive(Default)]
-pub struct Problem {
-    /// The requirements that _must_ have one candidate solvable be included in the
+///
+/// This struct is generic over the type `S` of the collection of soft requirements passed
+/// to the solver, typically expected to be a type implementing [`IntoIterator`].
+///
+/// This struct follows the builder pattern and can have its fields set by one of the available
+/// setter methods.
+pub struct Problem<S> {
+    requirements: Vec<Requirement>,
+    constraints: Vec<VersionSetId>,
+    soft_requirements: S,
+}
+
+impl Default for Problem<std::iter::Empty<SolvableId>> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Problem<std::iter::Empty<SolvableId>> {
+    /// Creates a new empty [`Problem`]. Use the setter methods to build the problem
+    /// before passing it to the solver to be solved.
+    pub fn new() -> Self {
+        Self {
+            requirements: Default::default(),
+            constraints: Default::default(),
+            soft_requirements: Default::default(),
+        }
+    }
+}
+
+impl<S: IntoIterator<Item = SolvableId>> Problem<S> {
+    /// Sets the requirements that _must_ have one candidate solvable be included in the
     /// solution.
-    pub requirements: Vec<Requirement>,
+    ///
+    /// Returns the [`Problem`] for further mutation or to pass to [`Solver::solve`].
+    pub fn requirements(self, requirements: Vec<Requirement>) -> Self {
+        Self {
+            requirements,
+            ..self
+        }
+    }
 
-    /// Additional constraints imposed on individual packages that the solvable (if any)
+    /// Sets the additional constraints imposed on individual packages that the solvable (if any)
     /// chosen for that package _must_ adhere to.
-    pub constraints: Vec<VersionSetId>,
+    ///
+    /// Returns the [`Problem`] for further mutation or to pass to [`Solver::solve`].
+    pub fn constraints(self, constraints: Vec<VersionSetId>) -> Self {
+        Self {
+            constraints,
+            ..self
+        }
+    }
 
-    /// A set of additional requirements that the solver should _try_ and fulfill once it has
+    /// Sets the additional requirements that the solver should _try_ and fulfill once it has
     /// found a solution to the main problem.
     ///
     /// An unsatisfiable soft requirement does not cause a conflict; the solver will try
@@ -54,7 +97,20 @@ pub struct Problem {
     /// Soft requirements are currently only specified as individual solvables to be
     /// included in the solution, however in the future they will be able to be specified
     /// as version sets.
-    pub soft_requirements: Vec<SolvableId>,
+    ///
+    /// # Returns
+    ///
+    /// Returns the [`Problem`] for further mutation or to pass to [`Solver::solve`].
+    pub fn soft_requirements<I: IntoIterator<Item = SolvableId>>(
+        self,
+        soft_requirements: I,
+    ) -> Problem<I> {
+        Problem {
+            requirements: self.requirements,
+            constraints: self.constraints,
+            soft_requirements,
+        }
+    }
 }
 
 /// Drives the SAT solving process.
@@ -201,7 +257,10 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
     ///
     /// If the solution process is cancelled (see [`DependencyProvider::should_cancel_with_value`]),
     /// returns an [`UnsolvableOrCancelled::Cancelled`] containing the cancellation value.
-    pub fn solve(&mut self, problem: Problem) -> Result<Vec<SolvableId>, UnsolvableOrCancelled> {
+    pub fn solve(
+        &mut self,
+        problem: Problem<impl IntoIterator<Item = SolvableId>>,
+    ) -> Result<Vec<SolvableId>, UnsolvableOrCancelled> {
         self.decision_tracker.clear();
         self.negative_assertions.clear();
         self.learnt_clauses.clear();


### PR DESCRIPTION
Changes the `Problem` input struct (introduced in #54) to use the builder pattern.

This allows the `soft_requirements` field to be an `Iterator` rather than a `Vec`, which prevents having to unnecessarily clone the `SolvableId`s passed to `soft_requirements` (which in some cases could be on the order of hundreds of thousands). Also, this prevents adding a new input argument to `Solver::solve` (i.e. a new field in `Problem`) from being a breaking change.

The C++ bindings remain unchanged and rely on using a simple `resolvo_cpp::Problem` struct as before; they do not expose the builder pattern.