### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/mamba-org/resolvo/compare/resolvo-v0.7.0...resolvo-v0.8.0) - 2024-09-09
+
+### Added
+
+- [**breaking**] decide on explicit requirements first ([#61](https://github.com/mamba-org/resolvo/pull/61))
+- add better timing notebook and measuring ([#64](https://github.com/mamba-org/resolvo/pull/64))
+- *(solver)* [**breaking**] Make `Problem` use builder pattern ([#62](https://github.com/mamba-org/resolvo/pull/62))
+
 ## [0.7.0](https://github.com/mamba-org/resolvo/compare/resolvo-v0.6.2...resolvo-v0.7.0) - 2024-08-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,7 +1154,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "resolvo"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ahash",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cpp", "tools/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Adolfo Ochagavía <github@adolfo.ochagavia.nl>", "Bas Zalmstra <zalmstra.bas@gmail.com>", "Tim de Jager <tdejager89@gmail.com>"]
 homepage = "https://github.com/mamba-org/resolvo"
 repository = "https://github.com/mamba-org/resolvo"

--- a/cpp/Cargo.toml
+++ b/cpp/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
-resolvo = { version = "0.7.0", path = "../" }
+resolvo = { version = "0.8.0", path = "../" }
 
 [build-dependencies]
 anyhow = "1"


### PR DESCRIPTION
## 🤖 New release
* `resolvo`: 0.7.0 -> 0.8.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/mamba-org/resolvo/compare/resolvo-v0.7.0...resolvo-v0.8.0) - 2024-09-09

### Added

- [**breaking**] decide on explicit requirements first ([#61](https://github.com/mamba-org/resolvo/pull/61))
- add better timing notebook and measuring ([#64](https://github.com/mamba-org/resolvo/pull/64))
- *(solver)* [**breaking**] Make `Problem` use builder pattern ([#62](https://github.com/mamba-org/resolvo/pull/62))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).