### PR TITLE
fix: constraint at root can conflict

### DIFF
--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -985,7 +985,7 @@ impl<'i, I: Interner> fmt::Display for DisplayUnsat<'i, I> {
                     &ConflictCause::Constrains(version_set_id) => {
                         writeln!(
                             f,
-                            "{indent}The constraint at the root level {version_set} could not be fulfilled",
+                            "{indent}root constraint '{version_set}' cannot be fulfilled",
                             version_set = self.interner.display_version_set(version_set_id),
                         )?;
                     }

--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -982,7 +982,14 @@ impl<'i, I: Interner> fmt::Display for DisplayUnsat<'i, I> {
 
                 // The only possible conflict at the root level is a Locked conflict
                 match conflict {
-                    ConflictCause::Constrains(_) | ConflictCause::ForbidMultipleInstances => {
+                    &ConflictCause::Constrains(version_set_id) => {
+                        writeln!(
+                            f,
+                            "{indent}The constraint at the root level {version_set} could not be fulfilled",
+                            version_set = self.interner.display_version_set(version_set_id),
+                        )?;
+                    }
+                    &ConflictCause::ForbidMultipleInstances => {
                         unreachable!()
                     }
                     &ConflictCause::Locked(solvable_id) => {

--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -985,7 +985,7 @@ impl<'i, I: Interner> fmt::Display for DisplayUnsat<'i, I> {
                     &ConflictCause::Constrains(version_set_id) => {
                         writeln!(
                             f,
-                            "{indent}root constraint '{version_set}' cannot be fulfilled",
+                            "{indent}constraint '{version_set}' cannot be fulfilled",
                             version_set = self.interner.display_version_set(version_set_id),
                         )?;
                     }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -355,46 +355,30 @@ impl<'s> SnapshotProvider<'s> {
         }
     }
 
-    /// Adds another requirement that matches any version of a package
+    /// Adds another requirement that matches any version of a package.
+    /// If you use "*" as the matcher, it will match any version of the package.
     pub fn add_package_requirement(&mut self, name: NameId, matcher: &str) -> VersionSetId {
         let id = self.snapshot.version_sets.max() + self.additional_version_sets.len();
-
         let package = self.package(name);
 
-        // match packages if not `*`
-        if matcher != "*" {
-            let matching_candidates = package
-                .solvables
-                .iter()
-                .copied()
-                .filter(|&s| {
-                    self.solvable(s)
-                        .display
-                        .contains(matcher)
-                })
-                .collect();
+        let matching_candidates = package
+            .solvables
+            .iter()
+            .copied()
+            .filter(|&s| matcher == "*" || self.solvable(s).display.contains(matcher))
+            .collect();
 
-            let version_set = VersionSet {
-                name,
-                display: format!("{} {}", package.name, matcher),
-                matching_candidates,
-            };
+        self.additional_version_sets.push(VersionSet {
+            name,
+            display: if matcher == "*" {
+                "*".to_string()
+            } else {
+                format!("{} {}", package.name, matcher)
+            },
+            matching_candidates,
+        });
 
-            self.additional_version_sets.push(version_set);
-            return VersionSetId::from_usize(id);
-        } else {
-            // if `*` match all packages
-            let matching_candidates = package.solvables.iter().copied().collect();
-
-            let version_set = VersionSet {
-                name,
-                display: "*".to_string(),
-                matching_candidates,
-            };
-
-            self.additional_version_sets.push(version_set);
-            return VersionSetId::from_usize(id);
-        }
+        VersionSetId::from_usize(id)
     }
 
     fn solvable(&self, solvable: SolvableId) -> &Solvable {

--- a/tests/snapshots/solver__root_constraints.snap
+++ b/tests/snapshots/solver__root_constraints.snap
@@ -5,4 +5,4 @@ expression: "solve_for_snapshot(snapshot_provider, &[union_req], &[icons_req])"
 The following packages are incompatible
 └─ union * can be installed with any of the following options:
    └─ union union=1
-├─ root constraint 'union 5' cannot be fulfilled
+├─ constraint 'union 5' cannot be fulfilled

--- a/tests/snapshots/solver__root_constraints.snap
+++ b/tests/snapshots/solver__root_constraints.snap
@@ -1,0 +1,8 @@
+---
+source: tests/solver.rs
+expression: "solve_for_snapshot(snapshot_provider, &[union_req], &[icons_req])"
+---
+The following packages are incompatible
+└─ union * can be installed with any of the following options:
+   └─ union union=1
+├─ root constraint 'union 5' cannot be fulfilled

--- a/tests/solver.rs
+++ b/tests/solver.rs
@@ -1374,7 +1374,6 @@ fn test_root_constraints() {
         ("union", 1, vec!["icons"]),
     ]);
 
-    let icons_name_id = provider.package_name("icons");
     let union_name_id = provider.package_name("union");
 
     let snapshot = provider.into_snapshot();
@@ -1429,9 +1428,14 @@ fn serialize_snapshot(snapshot: &DependencySnapshot, destination: impl AsRef<std
     serde_json::to_writer_pretty(file, snapshot).unwrap()
 }
 
-fn solve_for_snapshot(provider: SnapshotProvider, root_reqs: &[VersionSetId], root_constraints: &[VersionSetId]) -> String {
+fn solve_for_snapshot(
+    provider: SnapshotProvider,
+    root_reqs: &[VersionSetId],
+    root_constraints: &[VersionSetId],
+) -> String {
     let mut solver = Solver::new(provider);
-    let problem = Problem::new().requirements(root_reqs.iter().copied().map(Into::into).collect())
+    let problem = Problem::new()
+        .requirements(root_reqs.iter().copied().map(Into::into).collect())
         .constraints(root_constraints.iter().copied().map(Into::into).collect());
     match solver.solve(problem) {
         Ok(solvables) => transaction_to_string(solver.provider(), &solvables),

--- a/tests/solver.rs
+++ b/tests/solver.rs
@@ -1366,10 +1366,8 @@ fn test_snapshot_union_requirements() {
 
 #[test]
 fn test_root_constraints() {
-    let provider = BundleBoxProvider::from_packages(&[
-        ("icons", 1, vec![]),
-        ("union", 1, vec!["icons"]),
-    ]);
+    let provider =
+        BundleBoxProvider::from_packages(&[("icons", 1, vec![]), ("union", 1, vec!["icons"])]);
 
     let union_name_id = provider.package_name("union");
 

--- a/tests/solver.rs
+++ b/tests/solver.rs
@@ -1367,10 +1367,7 @@ fn test_snapshot_union_requirements() {
 #[test]
 fn test_root_constraints() {
     let provider = BundleBoxProvider::from_packages(&[
-        ("icons", 2, vec![]),
         ("icons", 1, vec![]),
-        ("intl", 5, vec![]),
-        ("intl", 3, vec![]),
         ("union", 1, vec!["icons"]),
     ]);
 
@@ -1381,12 +1378,12 @@ fn test_root_constraints() {
     let mut snapshot_provider = snapshot.provider();
 
     let union_req = snapshot_provider.add_package_requirement(union_name_id, "*");
-    let icons_req = snapshot_provider.add_package_requirement(union_name_id, "5");
+    let union_constraint = snapshot_provider.add_package_requirement(union_name_id, "5");
 
     assert_snapshot!(solve_for_snapshot(
         snapshot_provider,
         &[union_req],
-        &[icons_req]
+        &[union_constraint]
     ));
 }
 

--- a/tools/solve-snapshot/src/main.rs
+++ b/tools/solve-snapshot/src/main.rs
@@ -88,7 +88,7 @@ fn main() {
                 0 => {
                     // Add a package requirement
                     let (package, _) = snapshot.packages.iter().choose(&mut rng).unwrap();
-                    let package_requirement = provider.add_package_requirement(package);
+                    let package_requirement = provider.add_package_requirement(package, "*");
                     requirements.push(package_requirement.into());
                 }
                 1 => {


### PR DESCRIPTION
This fixes an issue that Jaime found in his work on `conda-rattler-solver`. 

In conda-rattler-solver a lot more constraints are used then we generally do in pixi and other projects, so this became apparent quite quickly.

I haven't been able to verify whether the message makes a lot of sense yet, though.