### PR TITLE
chore: release v0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4](https://github.com/mamba-org/resolvo/compare/resolvo-v0.8.3...resolvo-v0.8.4) - 2024-11-05
+
+### Fixed
+
+- constraint formatting ([#80](https://github.com/mamba-org/resolvo/pull/80))
+
 ## [0.8.3](https://github.com/mamba-org/resolvo/compare/resolvo-v0.8.2...resolvo-v0.8.3) - 2024-11-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "resolvo"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "ahash",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cpp", "tools/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Adolfo Ochagavía <github@adolfo.ochagavia.nl>", "Bas Zalmstra <zalmstra.bas@gmail.com>", "Tim de Jager <tdejager89@gmail.com>"]
 homepage = "https://github.com/mamba-org/resolvo"
 repository = "https://github.com/mamba-org/resolvo"

--- a/cpp/Cargo.toml
+++ b/cpp/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
-resolvo = { version = "0.8.3", path = "../" }
+resolvo = { version = "0.8.4", path = "../" }
 
 [build-dependencies]
 anyhow = "1"


### PR DESCRIPTION
## 🤖 New release
* `resolvo`: 0.8.3 -> 0.8.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.4](https://github.com/mamba-org/resolvo/compare/resolvo-v0.8.3...resolvo-v0.8.4) - 2024-11-05

### Fixed

- constraint formatting ([#80](https://github.com/mamba-org/resolvo/pull/80))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).