### PR TITLE
chore: add diagnostics and segmented vector

### DIFF
--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run rustfmt
         uses: actions-rust-lang/rustfmt@v1
       - name: Run clippy
-        run: cargo clippy --workspace
+        run: cargo clippy --workspace --all-features
 
   test:
     name: Test
@@ -54,6 +54,6 @@ jobs:
         with:
           components: rustfmt
       - name: Build
-        run: cargo build 
+        run: cargo build --all-features
       - name: Run tests
-        run: cargo test --workspace -- --nocapture
+        run: cargo test --workspace --all-features -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,6 +687,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "human_bytes"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
+
+[[package]]
 name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +850,15 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1096,14 +1111,17 @@ dependencies = [
  "elsa",
  "event-listener 5.3.1",
  "futures",
+ "human_bytes",
  "indexmap",
  "insta",
  "itertools",
  "petgraph",
  "proptest",
  "resolvo",
+ "segvec",
  "serde",
  "serde_json",
+ "tabwriter",
  "tokio",
  "tracing",
  "tracing-test",
@@ -1169,6 +1187,16 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "segvec"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3ab3d9bc0d11482ed0019aa9c2cee94a0b4890a0eb21ce2153d88b1816f877"
+dependencies = [
+ "either",
+ "num-integer",
+]
 
 [[package]]
 name = "serde"
@@ -1285,6 +1313,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tabwriter"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a327282c4f64f6dc37e3bba4c2b6842cc3a992f204fa58d917696a89f691e5f6"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ license = "BSD-3-Clause"
 edition = "2021"
 readme = "README.md"
 keywords = ["dependency", "solver", "version"]
-categories= ["algorithms"]
+categories = ["algorithms"]
 
 [package]
 name = "resolvo"
 version.workspace = true
 authors.workspace = true
-description= "Fast package resolver written in Rust (CDCL based SAT solving)"
+description = "Fast package resolver written in Rust (CDCL based SAT solving)"
 keywords.workspace = true
 categories.workspace = true
 homepage.workspace = true
@@ -25,6 +25,9 @@ repository.workspace = true
 license.workspace = true
 edition.workspace = true
 readme.workspace = true
+
+[features]
+diagnostics = ["tabwriter", "human_bytes"]
 
 [dependencies]
 ahash = "0.8.11"
@@ -40,6 +43,11 @@ indexmap = "2"
 tokio = { version = "1.37", features = ["rt"], optional = true }
 async-std = { version = "1.12", default-features = false, features = ["alloc", "default"], optional = true }
 version-ranges = { version = "0.1.0", optional = true }
+segvec = { version = "0.2.0" }
+
+# Dependencies for the diagnostics feature
+tabwriter = { version = "1.4.0", optional = true }
+human_bytes = { version = "0.4.3", optional = true }
 
 [dev-dependencies]
 insta = "1.39.0"

--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -588,42 +588,6 @@ impl Indenter {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_indenter_without_top_level_indent() {
-        let indenter = Indenter::new(false);
-
-        let indenter = indenter.push_level_with_order(ChildOrder::Last);
-        assert_eq!(indenter.get_indent(), "");
-
-        let indenter = indenter.push_level_with_order(ChildOrder::Last);
-        assert_eq!(indenter.get_indent(), "└─ ");
-    }
-
-    #[test]
-    fn test_indenter_with_multiple_siblings() {
-        let indenter = Indenter::new(true);
-
-        let indenter = indenter.push_level_with_order(ChildOrder::Last);
-        assert_eq!(indenter.get_indent(), "└─ ");
-
-        let indenter = indenter.push_level_with_order(ChildOrder::HasRemainingSiblings);
-        assert_eq!(indenter.get_indent(), "   ├─ ");
-
-        let indenter = indenter.push_level_with_order(ChildOrder::Last);
-        assert_eq!(indenter.get_indent(), "   │  └─ ");
-
-        let indenter = indenter.push_level_with_order(ChildOrder::Last);
-        assert_eq!(indenter.get_indent(), "   │     └─ ");
-
-        let indenter = indenter.push_level_with_order(ChildOrder::HasRemainingSiblings);
-        assert_eq!(indenter.get_indent(), "   │        ├─ ");
-    }
-}
-
 /// A struct implementing [`fmt::Display`] that generates a user-friendly
 /// representation of a conflict graph
 pub struct DisplayUnsat<'i, I: Interner> {
@@ -1010,5 +974,41 @@ impl<'i, I: Interner> fmt::Display for DisplayUnsat<'i, I> {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_indenter_without_top_level_indent() {
+        let indenter = Indenter::new(false);
+
+        let indenter = indenter.push_level_with_order(ChildOrder::Last);
+        assert_eq!(indenter.get_indent(), "");
+
+        let indenter = indenter.push_level_with_order(ChildOrder::Last);
+        assert_eq!(indenter.get_indent(), "└─ ");
+    }
+
+    #[test]
+    fn test_indenter_with_multiple_siblings() {
+        let indenter = Indenter::new(true);
+
+        let indenter = indenter.push_level_with_order(ChildOrder::Last);
+        assert_eq!(indenter.get_indent(), "└─ ");
+
+        let indenter = indenter.push_level_with_order(ChildOrder::HasRemainingSiblings);
+        assert_eq!(indenter.get_indent(), "   ├─ ");
+
+        let indenter = indenter.push_level_with_order(ChildOrder::Last);
+        assert_eq!(indenter.get_indent(), "   │  └─ ");
+
+        let indenter = indenter.push_level_with_order(ChildOrder::Last);
+        assert_eq!(indenter.get_indent(), "   │     └─ ");
+
+        let indenter = indenter.push_level_with_order(ChildOrder::HasRemainingSiblings);
+        assert_eq!(indenter.get_indent(), "   │        ├─ ");
     }
 }

--- a/src/solver/decision_map.rs
+++ b/src/solver/decision_map.rs
@@ -47,6 +47,11 @@ impl DecisionMap {
         }
     }
 
+    #[cfg(feature = "diagnostics")]
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
     pub fn reset(&mut self, solvable_id: InternalSolvableId) {
         let solvable_id = solvable_id.to_usize();
         if solvable_id < self.map.len() {

--- a/src/solver/decision_tracker.rs
+++ b/src/solver/decision_tracker.rs
@@ -27,6 +27,11 @@ impl DecisionTracker {
         self.propagate_index = 0;
     }
 
+    #[cfg(feature = "diagnostics")]
+    pub(crate) fn len(&self) -> usize {
+        self.map.len()
+    }
+
     #[inline(always)]
     pub(crate) fn assigned_value(&self, solvable_id: InternalSolvableId) -> Option<bool> {
         self.map.value(solvable_id)

--- a/src/solver/diagnostics.rs
+++ b/src/solver/diagnostics.rs
@@ -1,0 +1,99 @@
+use std::io::Write;
+
+use ahash::HashMap;
+use itertools::Itertools;
+
+use crate::{
+    runtime::AsyncRuntime,
+    solver::clause::{Clause, ClauseState},
+    DependencyProvider, Solver,
+};
+
+impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
+    /// Reports diagnostics about the current state of the solver.
+    pub(crate) fn report_diagnostics(&self) {
+        let mut forbid_clauses_by_name = HashMap::default();
+        let mut forbid_clauses = 0usize;
+        let mut requires_clauses = 0usize;
+        let mut locked_clauses = 0usize;
+        let mut learned_clauses = 0usize;
+        let mut constrains_clauses = 0usize;
+        let clauses = self.clauses.kinds.borrow();
+        for clause in clauses.iter() {
+            match clause {
+                Clause::ForbidMultipleInstances(_a, _b, name_id) => {
+                    let count = forbid_clauses_by_name.entry(name_id).or_insert(0usize);
+                    *count += 1;
+                    forbid_clauses += 1;
+                }
+                Clause::Requires(..) => {
+                    requires_clauses += 1;
+                }
+                Clause::Lock(..) => {
+                    locked_clauses += 1;
+                }
+                Clause::Learnt(..) => {
+                    learned_clauses += 1;
+                }
+                Clause::Constrains(..) => {
+                    constrains_clauses += 1;
+                }
+                _ => {}
+            }
+        }
+
+        let mut writer = tabwriter::TabWriter::new(Vec::new());
+        writeln!(
+            writer,
+            "Total number of solvables:\t{}",
+            self.decision_tracker.len()
+        )
+        .unwrap();
+        writeln!(
+            writer,
+            "Total number of watches:\t{} ({})",
+            self.watches.len(),
+            human_bytes::human_bytes(self.watches.size_in_bytes() as f64)
+        )
+        .unwrap();
+        writeln!(
+            writer,
+            "Total number of clauses:\t{} ({})",
+            clauses.len(),
+            human_bytes::human_bytes(
+                (clauses.len()
+                    * (std::mem::size_of::<Clause>() + std::mem::size_of::<ClauseState>()))
+                    as f64
+            )
+        )
+        .unwrap();
+        writeln!(writer, "- Requires:\t{}", requires_clauses).unwrap();
+        writeln!(writer, "- Constrains:\t{}", constrains_clauses).unwrap();
+        writeln!(writer, "- Lock:\t{}", locked_clauses).unwrap();
+        writeln!(writer, "- Learned:\t{}", learned_clauses).unwrap();
+        writeln!(writer, "- ForbidMultiple:\t{}", forbid_clauses).unwrap();
+
+        for (name_id, count) in forbid_clauses_by_name
+            .iter()
+            .sorted_by_key(|(_, count)| **count)
+            .rev()
+            .take(5)
+        {
+            writeln!(
+                writer,
+                "  - {}:\t{}",
+                self.provider().display_name(**name_id),
+                count
+            )
+            .unwrap();
+        }
+
+        if forbid_clauses_by_name.len() > 5 {
+            writeln!(writer, "  ...").unwrap();
+        }
+
+        let report = String::from_utf8(writer.into_inner().unwrap()).unwrap();
+
+        tracing::info!("Solver diagnostics:\n{}", report);
+    }
+}

--- a/src/solver/watch_map.rs
+++ b/src/solver/watch_map.rs
@@ -18,6 +18,16 @@ impl WatchMap {
         }
     }
 
+    #[cfg(feature = "diagnostics")]
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    #[cfg(feature = "diagnostics")]
+    pub fn size_in_bytes(&self) -> usize {
+        self.len() * std::mem::size_of::<(Literal, ClauseId)>()
+    }
+
     pub(crate) fn start_watching(&mut self, clause: &mut ClauseState, clause_id: ClauseId) {
         for (watch_index, watched_literal) in clause.watched_literals.into_iter().enumerate() {
             let already_watching = self

--- a/tests/solver.rs
+++ b/tests/solver.rs
@@ -123,9 +123,7 @@ impl Spec {
     pub fn parse_union(
         spec: &str,
     ) -> impl Iterator<Item = Result<Self, <Self as FromStr>::Err>> + '_ {
-        spec.split('|')
-            .map(str::trim)
-            .map(|dep| Spec::from_str(dep))
+        spec.split('|').map(str::trim).map(Spec::from_str)
     }
 }
 
@@ -386,7 +384,7 @@ impl DependencyProvider for BundleBoxProvider {
         candidates
             .iter()
             .copied()
-            .filter(|s| range.contains(&self.pool.resolve_solvable(*s).record) == !inverse)
+            .filter(|s| range.contains(&self.pool.resolve_solvable(*s).record) != inverse)
             .collect()
     }
 
@@ -538,7 +536,7 @@ impl DependencyProvider for BundleBoxProvider {
 }
 
 /// Create a string from a [`Transaction`]
-fn transaction_to_string(interner: &impl Interner, solvables: &Vec<SolvableId>) -> String {
+fn transaction_to_string(interner: &impl Interner, solvables: &[SolvableId]) -> String {
     use std::fmt::Write;
     let mut buf = String::new();
     for solvable in solvables


### PR DESCRIPTION
This PR adds the use of `segvec::SegVec` to allocate clauses. This reduces the number of very large allocations performed by the library.

I also added functionality to report diagnostics to make it easier to debug what is going on.