### PR TITLE
fix: crash when a union requirement has no candidates

### DIFF
--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -1089,9 +1089,12 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
 
                     // Find the first candidate that is not yet assigned a value or find the first
                     // value that makes this clause true.
-                    candidate = candidates
-                        .iter()
-                        .try_fold(None, |first_candidate, &candidate| {
+                    candidate = candidates.iter().try_fold(
+                        match candidate {
+                            ControlFlow::Continue(x) => x,
+                            _ => None,
+                        },
+                        |first_candidate, &candidate| {
                             let assigned_value =
                                 self.decision_tracker.assigned_value(candidate.into());
                             ControlFlow::Continue(match assigned_value {
@@ -1137,7 +1140,8 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
                                     }
                                 },
                             })
-                        });
+                        },
+                    );
 
                     // Stop searching if we found a candidate that makes the clause true.
                     if candidate.is_break() {

--- a/tests/solver.rs
+++ b/tests/solver.rs
@@ -1366,6 +1366,17 @@ fn test_snapshot_union_requirements() {
 }
 
 #[test]
+fn test_union_empty_requirements() {
+    let provider = BundleBoxProvider::from_packages(&[("a", 1, vec!["b 1 | c"]), ("b", 1, vec![])]);
+
+    let result = solve_snapshot(provider, &["a"]);
+    assert_snapshot!(result, @r"
+    a=1
+    b=1
+    ");
+}
+
+#[test]
 fn test_root_constraints() {
     let provider =
         BundleBoxProvider::from_packages(&[("icons", 1, vec![]), ("union", 1, vec!["icons"])]);


### PR DESCRIPTION
Fixes #90 

Fixes a crash that was caused by a union requirement with a last term that had no candidates. I added a test that crashes on main and succeeds with this PR.