### PR TITLE
chore: release v0.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.6](https://github.com/mamba-org/resolvo/compare/resolvo-v0.8.5...resolvo-v0.8.6) - 2025-01-08
+
+### Other
+
+- update all dependencies (#96)
+
 ## [0.8.5](https://github.com/mamba-org/resolvo/compare/resolvo-v0.8.4...resolvo-v0.8.5) - 2025-01-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resolvo"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "ahash",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cpp", "tools/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.5"
+version = "0.8.6"
 authors = ["Adolfo Ochagavía <github@adolfo.ochagavia.nl>", "Bas Zalmstra <zalmstra.bas@gmail.com>", "Tim de Jager <tdejager89@gmail.com>"]
 homepage = "https://github.com/mamba-org/resolvo"
 repository = "https://github.com/mamba-org/resolvo"

--- a/cpp/Cargo.toml
+++ b/cpp/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
-resolvo = { version = "0.8.5", path = "../" }
+resolvo = { version = "0.8.6", path = "../" }
 
 [build-dependencies]
 anyhow = "1"


### PR DESCRIPTION
## 🤖 New release
* `resolvo`: 0.8.5 -> 0.8.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.6](https://github.com/mamba-org/resolvo/compare/resolvo-v0.8.5...resolvo-v0.8.6) - 2025-01-08

### Other

- update all dependencies (#96)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).