### PR TITLE
refactor: simplify watchmap traversal

### DIFF
--- a/src/internal/id.rs
+++ b/src/internal/id.rs
@@ -114,6 +114,7 @@ impl ArenaId for ClauseId {
         Self(unsafe { NonZeroU32::new_unchecked((x + 1).try_into().expect("clause id too big")) })
     }
 
+    #[inline]
     fn to_usize(self) -> usize {
         (self.0.get() - 1) as usize
     }

--- a/src/internal/id.rs
+++ b/src/internal/id.rs
@@ -114,7 +114,6 @@ impl ArenaId for ClauseId {
         Self(unsafe { NonZeroU32::new_unchecked((x + 1).try_into().expect("clause id too big")) })
     }
 
-    #[inline]
     fn to_usize(self) -> usize {
         (self.0.get() - 1) as usize
     }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -3,3 +3,6 @@ pub mod frozen_copy_map;
 pub mod id;
 pub mod mapping;
 pub mod small_vec;
+mod unwrap_unchecked;
+
+pub use unwrap_unchecked::debug_expect_unchecked;

--- a/src/internal/unwrap_unchecked.rs
+++ b/src/internal/unwrap_unchecked.rs
@@ -1,0 +1,11 @@
+#[track_caller]
+pub unsafe fn debug_expect_unchecked<T>(opt: Option<T>, msg: &str) -> T {
+    #[cfg(debug_assertions)]
+    {
+        opt.expect(msg)
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        opt.unwrap_unchecked()
+    }
+}

--- a/src/internal/unwrap_unchecked.rs
+++ b/src/internal/unwrap_unchecked.rs
@@ -1,8 +1,10 @@
+/// An unsafe method that unwraps an option without checking if it is `None` in
+/// release mode but does check the value in debug mode.
 #[track_caller]
-pub unsafe fn debug_expect_unchecked<T>(opt: Option<T>, msg: &str) -> T {
+pub unsafe fn debug_expect_unchecked<T>(opt: Option<T>, _msg: &str) -> T {
     #[cfg(debug_assertions)]
     {
-        opt.expect(msg)
+        opt.expect(_msg)
     }
     #[cfg(not(debug_assertions))]
     {

--- a/src/solver/clause.rs
+++ b/src/solver/clause.rs
@@ -813,4 +813,13 @@ mod test {
             std::mem::size_of::<Option<[Literal; 2]>>()
         );
     }
+
+    #[test]
+    fn test_watched_literal_size() {
+        assert_eq!(std::mem::size_of::<WatchedLiterals>(), 16);
+        assert_eq!(
+            std::mem::size_of::<Option<WatchedLiterals>>(),
+            std::mem::size_of::<WatchedLiterals>()
+        );
+    }
 }

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -1463,8 +1463,10 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
         let clause_id = self.clauses.alloc(state, kind);
         self.learnt_clause_ids.push(clause_id);
         if has_watches {
-            self.watches
-                .start_watching(&mut self.clauses.watched_literals[clause_id.to_usize()], clause_id);
+            self.watches.start_watching(
+                &mut self.clauses.watched_literals[clause_id.to_usize()],
+                clause_id,
+            );
         }
 
         tracing::debug!("│├ Learnt disjunction:",);
@@ -1730,7 +1732,9 @@ async fn add_clauses_for_solvables<D: DependencyProvider>(
                                 WatchedLiterals::lock(locked_solvable_var, other_candidate_var);
                             let clause_id = clauses.alloc(state, kind);
 
-                            debug_assert!(clauses.watched_literals[clause_id.to_usize()].has_watches());
+                            debug_assert!(
+                                clauses.watched_literals[clause_id.to_usize()].has_watches()
+                            );
                             output.clauses_to_watch.push(clause_id);
                         }
                     }
@@ -1814,7 +1818,9 @@ async fn add_clauses_for_solvables<D: DependencyProvider>(
                                 name_id,
                             );
                             let clause_id = clauses.alloc(state, kind);
-                            debug_assert!(clauses.watched_literals[clause_id.to_usize()].has_watches());
+                            debug_assert!(
+                                clauses.watched_literals[clause_id.to_usize()].has_watches()
+                            );
                             output.clauses_to_watch.push(clause_id);
                         },
                         || variable_map.alloc_forbid_multiple_variable(name_id),

--- a/src/solver/watch_map.rs
+++ b/src/solver/watch_map.rs
@@ -1,6 +1,6 @@
 use crate::{
     internal::{arena::ArenaId, id::ClauseId, mapping::Mapping},
-    solver::clause::{ClauseWatches, Literal},
+    solver::clause::{Literal, WatchedLiterals},
 };
 
 /// A map from literals to the clauses that are watching them. Each literal
@@ -20,7 +20,7 @@ impl WatchMap {
 
     /// Add the clause to the linked list of the literals that the clause is
     /// watching.
-    pub(crate) fn start_watching(&mut self, clause: &mut ClauseWatches, clause_id: ClauseId) {
+    pub(crate) fn start_watching(&mut self, clause: &mut WatchedLiterals, clause_id: ClauseId) {
         for (watch_index, watched_literal) in
             clause.watched_literals.into_iter().flatten().enumerate()
         {
@@ -38,7 +38,7 @@ impl WatchMap {
     /// literal.
     pub fn cursor<'a>(
         &'a mut self,
-        watches: &'a mut [ClauseWatches],
+        watches: &'a mut [WatchedLiterals],
         literal: Literal,
     ) -> Option<WatchMapCursor<'a>> {
         let clause_id = *self.map.get(literal)?;
@@ -67,10 +67,10 @@ impl WatchMap {
 }
 
 struct WatchNode {
-    /// The index of the [`ClauseWatches`]
+    /// The index of the [`WatchedLiterals`]
     clause_id: ClauseId,
 
-    /// A [`ClauseWatches`] contains the state for two linked lists. This index
+    /// A [`WatchedLiterals`] contains the state for two linked lists. This index
     /// indicates which of the two linked-list nodes is referenced.
     watch_index: usize,
 }
@@ -88,7 +88,7 @@ pub struct WatchMapCursor<'a> {
     watch_map: &'a mut WatchMap,
 
     /// The nodes of the linked list.
-    watches: &'a mut [ClauseWatches],
+    watches: &'a mut [WatchedLiterals],
 
     /// The literal who's linked list is being navigated.
     literal: Literal,
@@ -147,7 +147,7 @@ impl<'a> WatchMapCursor<'a> {
     }
 
     /// Returns the watches of the current clause.
-    pub fn watches(&mut self) -> &mut ClauseWatches {
+    pub fn watches(&mut self) -> &mut WatchedLiterals {
         &mut self.watches[self.current.clause_id.to_usize()]
     }
 

--- a/src/solver/watch_map.rs
+++ b/src/solver/watch_map.rs
@@ -1,5 +1,5 @@
 use crate::{
-    internal::{id::ClauseId, mapping::Mapping},
+    internal::{arena::ArenaId, id::ClauseId, mapping::Mapping},
     solver::clause::{ClauseWatches, Literal},
 };
 
@@ -33,39 +33,165 @@ impl WatchMap {
         }
     }
 
-    pub(crate) fn update_watched(
-        &mut self,
-        predecessor_clause: Option<&mut ClauseWatches>,
-        clause: &mut ClauseWatches,
-        clause_id: ClauseId,
-        watch_index: usize,
-        previous_watch: Literal,
-        new_watch: Literal,
-    ) {
-        // Remove this clause from its current place in the linked list, because we
-        // are no longer watching what brought us here
-        if let Some(predecessor_clause) = predecessor_clause {
-            // Unlink the clause
-            predecessor_clause.unlink_clause(clause, previous_watch, watch_index);
-        } else if let Some(next_watch) = clause.next_watches[watch_index] {
-            // This was the first clause in the chain
-            self.map.insert(previous_watch, next_watch);
+    /// Returns a [`WatchMapCursor`] that can be used to navigate and manipulate
+    /// the linked list of the clauses that are watching the specified
+    /// literal.
+    pub fn cursor<'a>(
+        &'a mut self,
+        watches: &'a mut [ClauseWatches],
+        literal: Literal,
+    ) -> Option<WatchMapCursor<'a>> {
+        let clause_id = *self.map.get(literal)?;
+        let watch_index = if watches[clause_id.to_usize()].watched_literals[0] == Some(literal) {
+            0
         } else {
-            self.map.unset(previous_watch);
-        }
+            debug_assert_eq!(
+                watches[clause_id.to_usize()].watched_literals[1],
+                Some(literal),
+                "the clause is not actually watching the literal"
+            );
+            1
+        };
 
-        // Set the new watch
-        clause.watched_literals[watch_index] = Some(new_watch);
-        let previous_clause_id = self.map.insert(new_watch, clause_id);
-        clause.next_watches[watch_index] = previous_clause_id;
+        Some(WatchMapCursor {
+            watch_map: self,
+            watches,
+            literal,
+            previous: None,
+            current: WatchNode {
+                clause_id,
+                watch_index,
+            },
+        })
+    }
+}
+
+struct WatchNode {
+    /// The index of the [`ClauseWatches`]
+    clause_id: ClauseId,
+
+    /// A [`ClauseWatches`] contains the state for two linked lists. This index
+    /// indicates which of the two linked-list nodes is referenced.
+    watch_index: usize,
+}
+
+/// The watchmap contains a linked-list of clauses that are watching a certain
+/// literal. This linked-list is a singly linked list, which requires some
+/// administration when trying to modify the list. The [`WatchMapCursor`] is a
+/// utility that allows navigating the linked-list and manipulate it.
+///
+/// A cursor is created using [`WatchMap::cursor`]. The cursor can iterate
+/// through all the clauses using [`WatchMapCursor::next`] and a single watch
+/// can be updated using the [`WatchMapCursor::update`] method.
+pub struct WatchMapCursor<'a> {
+    /// The watchmap that is being navigated.
+    watch_map: &'a mut WatchMap,
+
+    /// The nodes of the linked list.
+    watches: &'a mut [ClauseWatches],
+
+    /// The literal who's linked list is being navigated.
+    literal: Literal,
+
+    /// The previous node we iterated or `None` if this is the head.
+    previous: Option<WatchNode>,
+
+    /// The current node.
+    current: WatchNode,
+}
+
+impl<'a> WatchMapCursor<'a> {
+    /// Skip to the next node in the linked list. Returns `None` if there is no
+    /// next node.
+    pub fn next(mut self) -> Option<Self> {
+        let next = self.next_node()?;
+
+        self.previous = Some(self.current);
+        self.current = next;
+
+        Some(self)
     }
 
-    /// Returns the id of the first clause that is watching the specified
-    /// literal.
-    pub(crate) fn first_clause_watching_literal(
-        &mut self,
-        watched_literal: Literal,
-    ) -> Option<ClauseId> {
-        self.map.get(watched_literal).copied()
+    /// Returns the next node in the linked list or `None` if there is no next.
+    fn next_node(&self) -> Option<WatchNode> {
+        let next_clause_id =
+            self.watches[self.current.clause_id.to_usize()].next_watches[self.current.watch_index]?;
+        let next_clause_watch_index =
+            if self.watches[next_clause_id.to_usize()].watched_literals[0] == Some(self.literal) {
+                0
+            } else {
+                debug_assert_eq!(
+                    self.watches[next_clause_id.to_usize()].watched_literals[1],
+                    Some(self.literal),
+                    "the clause is not actually watching the literal"
+                );
+                1
+            };
+
+        Some(WatchNode {
+            clause_id: next_clause_id,
+            watch_index: next_clause_watch_index,
+        })
+    }
+
+    /// Returns the other literal that the current clause is watching.
+    pub fn other_literal(&self) -> Literal {
+        self.watches[self.current.clause_id.to_usize()].watched_literals
+            [1 - self.current.watch_index]
+            .expect("clauses never watch just one literal")
+    }
+
+    /// The current clause that is being navigated.
+    pub fn clause_id(&self) -> ClauseId {
+        self.current.clause_id
+    }
+
+    /// Returns the watches of the current clause.
+    pub fn watches(&mut self) -> &mut ClauseWatches {
+        &mut self.watches[self.current.clause_id.to_usize()]
+    }
+
+    /// Returns the index of the current watch in the current clause.
+    pub fn watch_index(&self) -> usize {
+        self.current.watch_index
+    }
+
+    /// Update the current watch to a new literal. This removes the current node
+    /// from the linked-list and sets up a watch on the new literal.
+    ///
+    /// Returns a cursor that points to the next node in the linked list or
+    /// `None` if there is no next.
+    pub fn update(mut self, new_watch: Literal) -> Option<Self> {
+        debug_assert_ne!(
+            new_watch, self.literal,
+            "cannot update watch to the same literal"
+        );
+
+        let clause_idx = self.current.clause_id.to_usize();
+        let next_node = self.next_node();
+
+        // Update the previous node to point to the next node in the linked list
+        // (effectively removing this one).
+        if let Some(previous) = &self.previous {
+            // If there is a previous node we update that node to point to the next.
+            self.watches[previous.clause_id.to_usize()].next_watches[previous.watch_index] =
+                next_node.as_ref().map(|node| node.clause_id);
+        } else if let Some(next_clause_id) = next_node.as_ref().map(|node| node.clause_id) {
+            // If there is no previous node, we are the head of the linked list.
+            self.watch_map.map.insert(self.literal, next_clause_id);
+        } else {
+            self.watch_map.map.unset(self.literal);
+        }
+
+        // Set the new watch for the current clause.
+        let watch = &mut self.watches[clause_idx];
+        watch.watched_literals[self.current.watch_index] = Some(new_watch);
+        let previous_clause_id = self.watch_map.map.insert(new_watch, self.current.clause_id);
+        watch.next_watches[self.current.watch_index] = previous_clause_id;
+
+        // Update the current
+        self.current = next_node?;
+
+        Some(self)
     }
 }


### PR DESCRIPTION
This PR cleans up the code by adding a new type for traversing and modifying the watchmap. The propagation loop contained a number of bookkeeping locals which distract from the actual propagation algorithm. There were also methods to manipulate the watches and the watchmap in different places, they are now all consolidated in the `WatchMapCursor` struct. 

Using the cursor is very simple: `WatchMap::cursor` is used to create a cursor to iterate the linked list of watches. `WatchMapCursor::next` moves the cursor to the next clause watching a certain literal. `WatchMapCursor::update` modifies the current clause/watch to watch a different literal. This method performs all the bookkeeping of the linked lists to ensure consistency.

Hopefully this makes the code easier to understand.