### PR TITLE
chore: release v0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.3](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.10.2...resolvo-v0.10.3) - 2026-05-20
+
+### Other
+
+- encoding optimizations ([#221](https://github.com/prefix-dev/resolvo/pull/221))
+- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions from 5.0.3 to 5.0.4 ([#215](https://github.com/prefix-dev/resolvo/pull/215))
+- *(ci)* bump actions-rust-lang/setup-rust-toolchain from 1.15.4 to 1.16.1 ([#218](https://github.com/prefix-dev/resolvo/pull/218))
+- *(ci)* bump MarcoIeni/release-plz-action from 0.5.128 to 0.5.129 ([#219](https://github.com/prefix-dev/resolvo/pull/219))
+- Add an example sudoku solver ([#220](https://github.com/prefix-dev/resolvo/pull/220))
+- *(ci)* bump prefix-dev/setup-pixi from 0.9.4 to 0.9.5 ([#216](https://github.com/prefix-dev/resolvo/pull/216))
+- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#214](https://github.com/prefix-dev/resolvo/pull/214))
+- *(ci)* bump MarcoIeni/release-plz-action from 0.5.127 to 0.5.128 ([#211](https://github.com/prefix-dev/resolvo/pull/211))
+- *(ci)* bump actions-rust-lang/setup-rust-toolchain ([#212](https://github.com/prefix-dev/resolvo/pull/212))
+- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#213](https://github.com/prefix-dev/resolvo/pull/213))
+- *(ci)* bump actions-rust-lang/setup-rust-toolchain ([#209](https://github.com/prefix-dev/resolvo/pull/209))
+- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#210](https://github.com/prefix-dev/resolvo/pull/210))
+- *(ci)* bump MarcoIeni/release-plz-action from 0.5.126 to 0.5.127 ([#208](https://github.com/prefix-dev/resolvo/pull/208))
+- *(ci)* bump actions/checkout from 6.0.1 to 6.0.2 ([#204](https://github.com/prefix-dev/resolvo/pull/204))
+- *(ci)* bump prefix-dev/setup-pixi from 0.9.3 to 0.9.4 ([#205](https://github.com/prefix-dev/resolvo/pull/205))
+- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#206](https://github.com/prefix-dev/resolvo/pull/206))
+- *(ci)* bump MarcoIeni/release-plz-action from 0.5.121 to 0.5.126 ([#207](https://github.com/prefix-dev/resolvo/pull/207))
+- *(ci)* bump MarcoIeni/release-plz-action from 0.5.120 to 0.5.121 ([#200](https://github.com/prefix-dev/resolvo/pull/200))
+- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#197](https://github.com/prefix-dev/resolvo/pull/197))
+- *(ci)* bump actions-rust-lang/rustfmt from 1.1.1 to 1.1.2 ([#196](https://github.com/prefix-dev/resolvo/pull/196))
+- update banner to new style ([#194](https://github.com/prefix-dev/resolvo/pull/194))
+
 ## [0.10.2](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.10.1...resolvo-v0.10.2) - 2025-12-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resolvo"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "ahash",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cpp", "tools/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.2"
+version = "0.10.3"
 authors = [
     "Adolfo Ochagavía <github@adolfo.ochagavia.nl>",
     "Bas Zalmstra <zalmstra.bas@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `resolvo`: 0.10.2 -> 0.10.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.10.3](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.10.2...resolvo-v0.10.3) - 2026-05-20

### Other

- encoding optimizations ([#221](https://github.com/prefix-dev/resolvo/pull/221))
- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions from 5.0.3 to 5.0.4 ([#215](https://github.com/prefix-dev/resolvo/pull/215))
- *(ci)* bump actions-rust-lang/setup-rust-toolchain from 1.15.4 to 1.16.1 ([#218](https://github.com/prefix-dev/resolvo/pull/218))
- *(ci)* bump MarcoIeni/release-plz-action from 0.5.128 to 0.5.129 ([#219](https://github.com/prefix-dev/resolvo/pull/219))
- Add an example sudoku solver ([#220](https://github.com/prefix-dev/resolvo/pull/220))
- *(ci)* bump prefix-dev/setup-pixi from 0.9.4 to 0.9.5 ([#216](https://github.com/prefix-dev/resolvo/pull/216))
- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#214](https://github.com/prefix-dev/resolvo/pull/214))
- *(ci)* bump MarcoIeni/release-plz-action from 0.5.127 to 0.5.128 ([#211](https://github.com/prefix-dev/resolvo/pull/211))
- *(ci)* bump actions-rust-lang/setup-rust-toolchain ([#212](https://github.com/prefix-dev/resolvo/pull/212))
- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#213](https://github.com/prefix-dev/resolvo/pull/213))
- *(ci)* bump actions-rust-lang/setup-rust-toolchain ([#209](https://github.com/prefix-dev/resolvo/pull/209))
- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#210](https://github.com/prefix-dev/resolvo/pull/210))
- *(ci)* bump MarcoIeni/release-plz-action from 0.5.126 to 0.5.127 ([#208](https://github.com/prefix-dev/resolvo/pull/208))
- *(ci)* bump actions/checkout from 6.0.1 to 6.0.2 ([#204](https://github.com/prefix-dev/resolvo/pull/204))
- *(ci)* bump prefix-dev/setup-pixi from 0.9.3 to 0.9.4 ([#205](https://github.com/prefix-dev/resolvo/pull/205))
- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#206](https://github.com/prefix-dev/resolvo/pull/206))
- *(ci)* bump MarcoIeni/release-plz-action from 0.5.121 to 0.5.126 ([#207](https://github.com/prefix-dev/resolvo/pull/207))
- *(ci)* bump MarcoIeni/release-plz-action from 0.5.120 to 0.5.121 ([#200](https://github.com/prefix-dev/resolvo/pull/200))
- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#197](https://github.com/prefix-dev/resolvo/pull/197))
- *(ci)* bump actions-rust-lang/rustfmt from 1.1.1 to 1.1.2 ([#196](https://github.com/prefix-dev/resolvo/pull/196))
- update banner to new style ([#194](https://github.com/prefix-dev/resolvo/pull/194))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).