### PR TITLE
perf: minor performance optimizations

### DIFF
--- a/src/conditional_requirement.rs
+++ b/src/conditional_requirement.rs
@@ -2,7 +2,7 @@ use crate::{Requirement, VersionSetId, VersionSetUnionId, internal::id::Conditio
 
 /// A [`ConditionalRequirement`] is a requirement that is only enforced when a
 /// certain condition holds.
-#[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConditionalRequirement {
     /// The requirement is enforced only when the condition evaluates to true.

--- a/src/solver/clause.rs
+++ b/src/solver/clause.rs
@@ -743,17 +743,11 @@ mod test {
             clause.as_ref().unwrap().watched_literals[0].variable(),
             parent
         );
-        assert_eq!(
-            clause.unwrap().watched_literals[1].variable(),
-            candidate1.into()
-        );
+        assert_eq!(clause.unwrap().watched_literals[1].variable(), candidate1);
 
         // No conflict, still one candidate available
         decisions
-            .try_add_decision(
-                Decision::new(candidate1.into(), false, ClauseId::from_usize(0)),
-                1,
-            )
+            .try_add_decision(Decision::new(candidate1, false, ClauseId::from_usize(0)), 1)
             .unwrap();
         let (clause, conflict, _kind) = WatchedLiterals::requires(
             parent,
@@ -769,13 +763,13 @@ mod test {
         );
         assert_eq!(
             clause.as_ref().unwrap().watched_literals[1].variable(),
-            candidate2.into()
+            candidate2
         );
 
         // Conflict, no candidates available
         decisions
             .try_add_decision(
-                Decision::new(candidate2.into(), false, ClauseId::install_root()),
+                Decision::new(candidate2, false, ClauseId::install_root()),
                 1,
             )
             .unwrap();
@@ -793,7 +787,7 @@ mod test {
         );
         assert_eq!(
             clause.as_ref().unwrap().watched_literals[1].variable(),
-            candidate1.into()
+            candidate1
         );
 
         // Panic

--- a/src/solver/encoding.rs
+++ b/src/solver/encoding.rs
@@ -235,7 +235,7 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
 
         // For each requirement request the matching candidates.
         for requirement in requirements {
-            self.queue_conditional_requirement(solvable_id, requirement.clone());
+            self.queue_conditional_requirement(solvable_id, *requirement);
         }
 
         // For each constraint, request the candidates that are non-matching

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -469,6 +469,8 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
             .unwrap_or(0);
 
         let mut level = starting_level;
+        let mut new_solvables: Vec<(VariableId, ClauseId)> = Vec::new();
+        let mut solvable_ids: Vec<SolvableOrRootId> = Vec::new();
 
         loop {
             if level == starting_level {
@@ -575,26 +577,27 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
             // Determine which solvables are part of the solution for which we did not yet
             // get any dependencies. If we find any such solvable it means we
             // did not arrive at the full solution yet.
-            let new_solvables: Vec<_> = self
-                .state
-                .decision_tracker
-                .stack()
-                // Filter only decisions that led to a positive assignment
-                .filter(|d| d.value)
-                // Select solvables for which we do not yet have dependencies
-                .filter(|d| {
-                    let Some(solvable_or_root) =
-                        d.variable.as_solvable_or_root(&self.state.variable_map)
-                    else {
-                        return false;
-                    };
-                    !self
-                        .state
-                        .clauses_added_for_solvable
-                        .contains(solvable_or_root)
-                })
-                .map(|d| (d.variable, d.derived_from))
-                .collect();
+            new_solvables.clear();
+            new_solvables.extend(
+                self.state
+                    .decision_tracker
+                    .stack()
+                    // Filter only decisions that led to a positive assignment
+                    .filter(|d| d.value)
+                    // Select solvables for which we do not yet have dependencies
+                    .filter(|d| {
+                        let Some(solvable_or_root) =
+                            d.variable.as_solvable_or_root(&self.state.variable_map)
+                        else {
+                            return false;
+                        };
+                        !self
+                            .state
+                            .clauses_added_for_solvable
+                            .contains(solvable_or_root)
+                    })
+                    .map(|d| (d.variable, d.derived_from)),
+            );
 
             if new_solvables.is_empty() {
                 // If no new literals were selected this solution is complete and we can return.
@@ -621,21 +624,20 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
             );
             tracing::debug!("====");
 
-            let new_solvables: Vec<SolvableOrRootId> = new_solvables
-                .iter()
-                .filter_map(|(variable, _)| {
-                    self.state
-                        .variable_map
-                        .origin(*variable)
-                        .as_solvable()
-                        .map(Into::into)
-                })
-                .collect::<Vec<_>>();
+            solvable_ids.clear();
+            solvable_ids.extend(new_solvables.iter().filter_map(|(variable, _)| {
+                self.state
+                    .variable_map
+                    .origin(*variable)
+                    .as_solvable()
+                    .map(SolvableOrRootId::from)
+            }));
 
             #[cfg(feature = "diagnostics")]
             let encoding_start = std::time::Instant::now();
             let conflicting_clauses = self.async_runtime.block_on(
-                Encoder::new(&mut self.state, &self.cache, root_deps, level).encode(new_solvables),
+                Encoder::new(&mut self.state, &self.cache, root_deps, level)
+                    .encode(solvable_ids.iter().copied()),
             )?;
             #[cfg(feature = "diagnostics")]
             {

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -1580,15 +1580,16 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
         }
 
         // Add the clause
-        let learnt_id = self.state.learnt_clauses.alloc(learnt.clone());
+        let learnt_id = self.state.learnt_clauses.alloc(learnt);
         self.state.learnt_why.insert(learnt_id, learnt_why);
 
-        let (watched_literals, kind) = WatchedLiterals::learnt(learnt_id, &learnt);
+        let (watched_literals, kind) =
+            WatchedLiterals::learnt(learnt_id, &self.state.learnt_clauses[learnt_id]);
         let clause_id = self.state.add_clause(watched_literals, kind);
         self.state.learnt_clause_ids.push(clause_id);
 
         tracing::debug!("│├ Learnt disjunction:",);
-        for lit in learnt {
+        for lit in &self.state.learnt_clauses[learnt_id] {
             tracing::debug!(
                 "││ - {}{}",
                 if lit.negate() { "NOT " } else { "" },

--- a/src/solver/variable_map.rs
+++ b/src/solver/variable_map.rs
@@ -32,7 +32,7 @@ pub struct VariableMap {
 }
 
 /// Describes the origin of a variable.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum VariableOrigin {
     /// The variable is the root of the decision tree.
     Root,
@@ -116,7 +116,7 @@ impl VariableMap {
     /// Returns the origin of a variable. The origin describes the semantics of
     /// a variable.
     pub fn origin(&self, variable_id: VariableId) -> VariableOrigin {
-        self.origins[variable_id.to_usize()].clone()
+        self.origins[variable_id.to_usize()]
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,4 +5,4 @@ mod mapping;
 mod pool;
 
 pub use mapping::{Mapping, MappingIter};
-pub use pool::{PackageName, Pool, Solvable, VersionSet};
+pub use pool::{IntoPackageName, PackageName, Pool, Solvable, VersionSet};

--- a/src/utils/pool.rs
+++ b/src/utils/pool.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Borrow,
     fmt::{Display, Formatter},
     hash::Hash,
 };
@@ -117,14 +118,14 @@ impl<VS: VersionSet, N: PackageName> Pool<VS, N> {
     /// [`Self::resolve_package_name`] function.
     pub fn intern_package_name<NValue>(&self, name: NValue) -> NameId
     where
-        NValue: Into<N>,
-        N: Clone,
+        NValue: Into<N> + AsRef<str>,
+        N: Clone + Borrow<str>,
     {
-        let name = name.into();
-        if let Some(id) = self.names_to_ids.get_copy(&name) {
+        if let Some(id) = self.names_to_ids.get_copy(name.as_ref()) {
             return id;
         }
 
+        let name = name.into();
         let next_id = self.package_names.alloc(name.clone());
         self.names_to_ids.insert_copy(name, next_id);
         next_id

--- a/src/utils/pool.rs
+++ b/src/utils/pool.rs
@@ -175,15 +175,12 @@ impl<VS: VersionSet, N: PackageName> Pool<VS, N> {
     /// Version sets are deduplicated. This means that if the same version set
     /// is inserted twice they will share the same [`VersionSetId`].
     pub fn intern_version_set(&self, package_name: NameId, version_set: VS) -> VersionSetId {
-        if let Some(entry) = self
-            .version_set_to_id
-            .get_copy(&(package_name, version_set.clone()))
-        {
+        let key = (package_name, version_set);
+        if let Some(entry) = self.version_set_to_id.get_copy(&key) {
             entry
         } else {
-            let id = self.version_sets.alloc((package_name, version_set.clone()));
-            self.version_set_to_id
-                .insert_copy((package_name, version_set), id);
+            let id = self.version_sets.alloc(key.clone());
+            self.version_set_to_id.insert_copy(key, id);
             id
         }
     }

--- a/src/utils/pool.rs
+++ b/src/utils/pool.rs
@@ -114,18 +114,23 @@ impl<VS: VersionSet, N: PackageName> Pool<VS, N> {
     /// are deduplicated. If the same name is inserted twice the same
     /// `NameId` will be returned.
     ///
+    /// Accepts either an owned `N` or a borrowed form of it (e.g. `&str`,
+    /// `&String`, or `String` when `N = String`). On a cache hit the input is
+    /// looked up via its borrowed form, avoiding allocation; only on a cache
+    /// miss is it converted into an owned `N`.
+    ///
     /// The original name can be resolved using the
     /// [`Self::resolve_package_name`] function.
     pub fn intern_package_name<NValue>(&self, name: NValue) -> NameId
     where
-        NValue: Into<N> + AsRef<str>,
-        N: Clone + Borrow<str>,
+        NValue: IntoPackageName<N>,
+        N: Borrow<NValue::Borrowed> + Clone,
     {
-        if let Some(id) = self.names_to_ids.get_copy(name.as_ref()) {
+        if let Some(id) = self.names_to_ids.get_copy(name.as_borrowed()) {
             return id;
         }
 
-        let name = name.into();
+        let name = name.into_owned();
         let next_id = self.package_names.alloc(name.clone());
         self.names_to_ids.insert_copy(name, next_id);
         next_id
@@ -281,6 +286,59 @@ impl NameId {
 pub trait PackageName: Eq + Hash {}
 
 impl<N: Eq + Hash> PackageName for N {}
+
+/// A value that can be used to look up or insert a package name in a [`Pool`].
+///
+/// Implemented for owned package names, references to package names, and
+/// (when `N = String`) for `&str`. The associated [`Borrowed`] type is the
+/// borrowed key used for the cache lookup, so a cache hit never has to
+/// allocate; only on a cache miss is [`into_owned`] called to produce the
+/// owned value that gets stored.
+///
+/// [`Borrowed`]: IntoPackageName::Borrowed
+/// [`into_owned`]: IntoPackageName::into_owned
+pub trait IntoPackageName<N: PackageName> {
+    /// The borrowed form used for cache lookups. `N` must implement
+    /// [`Borrow<Self::Borrowed>`] so the map key (`N`) and the lookup key
+    /// (`Self::Borrowed`) hash consistently.
+    type Borrowed: ?Sized + Hash + Eq;
+
+    /// Borrow `self` as the lookup key.
+    fn as_borrowed(&self) -> &Self::Borrowed;
+
+    /// Convert `self` into an owned `N` (only called on cache miss).
+    fn into_owned(self) -> N;
+}
+
+impl<N: PackageName> IntoPackageName<N> for N {
+    type Borrowed = N;
+    fn as_borrowed(&self) -> &N {
+        self
+    }
+    fn into_owned(self) -> N {
+        self
+    }
+}
+
+impl<N: PackageName + Clone> IntoPackageName<N> for &N {
+    type Borrowed = N;
+    fn as_borrowed(&self) -> &N {
+        self
+    }
+    fn into_owned(self) -> N {
+        self.clone()
+    }
+}
+
+impl IntoPackageName<String> for &str {
+    type Borrowed = str;
+    fn as_borrowed(&self) -> &str {
+        self
+    }
+    fn into_owned(self) -> String {
+        self.to_string()
+    }
+}
 
 /// A [`VersionSet`] describes a set of "versions". The trait defines whether a
 /// given version is part of the set or not.

--- a/tests/solver/bundle_box/mod.rs
+++ b/tests/solver/bundle_box/mod.rs
@@ -87,7 +87,7 @@ impl BundleBoxProvider {
     }
 
     pub fn intern_condition(&mut self, condition: &SpecCondition) -> ConditionId {
-        if let Some(id) = self.conditions.get(&condition) {
+        if let Some(id) = self.conditions.get(condition) {
             return *id;
         }
 
@@ -105,7 +105,7 @@ impl BundleBoxProvider {
     pub fn requirements(&mut self, requirements: &[&str]) -> Vec<ConditionalRequirement> {
         requirements
             .iter()
-            .map(|dep| ConditionalSpec::from_str(*dep).unwrap())
+            .map(|dep| ConditionalSpec::from_str(dep).unwrap())
             .map(|spec| {
                 let mut iter = spec
                     .specs
@@ -132,7 +132,7 @@ impl BundleBoxProvider {
     pub fn version_sets(&mut self, requirements: &[&str]) -> Vec<VersionSetId> {
         requirements
             .iter()
-            .map(|dep| Spec::from_str(*dep).unwrap())
+            .map(|dep| Spec::from_str(dep).unwrap())
             .map(|spec| {
                 let name = self.pool.intern_package_name(&spec.name);
                 self.pool.intern_version_set(name, spec.versions)
@@ -307,7 +307,7 @@ impl DependencyProvider for BundleBoxProvider {
         candidates
             .iter()
             .copied()
-            .filter(|s| range.contains(&self.pool.resolve_solvable(*s).record) == !inverse)
+            .filter(|s| range.contains(&self.pool.resolve_solvable(*s).record) != inverse)
             .collect()
     }
 

--- a/tests/solver/bundle_box/parser.rs
+++ b/tests/solver/bundle_box/parser.rs
@@ -40,9 +40,9 @@ where
         .then(
             any()
                 .try_map(|c: I::Token, span| {
-                    if c.to_ascii().map_or(false, |i| {
-                        i.is_ascii_alphanumeric() || i == b'_' || i == b'-'
-                    }) {
+                    if c.to_ascii()
+                        .is_some_and(|i| i.is_ascii_alphanumeric() || i == b'_' || i == b'-')
+                    {
                         Ok(())
                     } else {
                         Err(LabelError::expected_found(

--- a/tests/solver/main.rs
+++ b/tests/solver/main.rs
@@ -1049,8 +1049,8 @@ fn solve_for_snapshot<D: DependencyProvider>(
 ) -> String {
     let mut solver = Solver::new(provider);
     let problem = Problem::new()
-        .requirements(root_reqs.iter().cloned().collect())
-        .constraints(root_constraints.iter().copied().map(Into::into).collect());
+        .requirements(root_reqs.to_vec())
+        .constraints(root_constraints.to_vec());
     match solver.solve(problem) {
         Ok(solvables) => transaction_to_string(solver.provider(), &solvables),
         Err(UnsolvableOrCancelled::Unsolvable(conflict)) => {


### PR DESCRIPTION
Avoid some unnecessary allocations and de-allocations by re-using buffers and the intern pool

I haven't extensively benchmarked, but it was worth a couple of percent collectively for some of my specific cases

Likely mostly due to "Avoid String allocation on intern_package_name cache hits"