### PR TITLE
chore: release v0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.4](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.10.3...resolvo-v0.10.4) - 2026-06-02
+
+### Other
+
+- Add Pool::iter_solvables() ([#229](https://github.com/prefix-dev/resolvo/pull/229))
+- *(ci)* bump prefix-dev/setup-pixi from 0.9.5 to 0.9.6 ([#227](https://github.com/prefix-dev/resolvo/pull/227))
+- fix duplicated header and reorder entries in CHANGELOG ([#226](https://github.com/prefix-dev/resolvo/pull/226))
+- minor performance optimizations ([#223](https://github.com/prefix-dev/resolvo/pull/223))
+
 ## [0.10.3](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.10.2...resolvo-v0.10.3) - 2026-05-20
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resolvo"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "ahash",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cpp", "tools/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.3"
+version = "0.10.4"
 authors = [
     "Adolfo Ochagavía <github@adolfo.ochagavia.nl>",
     "Bas Zalmstra <zalmstra.bas@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `resolvo`: 0.10.3 -> 0.10.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.4](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.10.3...resolvo-v0.10.4) - 2026-06-02

### Other

- Add Pool::iter_solvables() ([#229](https://github.com/prefix-dev/resolvo/pull/229))
- *(ci)* bump prefix-dev/setup-pixi from 0.9.5 to 0.9.6 ([#227](https://github.com/prefix-dev/resolvo/pull/227))
- fix duplicated header and reorder entries in CHANGELOG ([#226](https://github.com/prefix-dev/resolvo/pull/226))
- minor performance optimizations ([#223](https://github.com/prefix-dev/resolvo/pull/223))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).