### PR TITLE
chore: fix duplicated header and reorder entries in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.10.1](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.10.0...resolvo-v0.10.1) - 2025-07-30
-
-### Other
-
-- strip whitespace if version set empty ([#164](https://github.com/prefix-dev/resolvo/pull/164))
-- *(ci)* bump MarcoIeni/release-plz-action from 0.5.109 to 0.5.110 ([#161](https://github.com/prefix-dev/resolvo/pull/161))
-- *(ci)* bump prefix-dev/setup-pixi from 0.8.12 to 0.8.14 ([#160](https://github.com/prefix-dev/resolvo/pull/160))
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
 ## [0.10.3](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.10.2...resolvo-v0.10.3) - 2026-05-20
 
 ### Other
@@ -77,6 +62,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(ci)* bump MarcoIeni/release-plz-action from 0.5.110 to 0.5.112 ([#169](https://github.com/prefix-dev/resolvo/pull/169))
 - *(ci)* bump prefix-dev/setup-pixi from 0.8.14 to 0.9.0 ([#170](https://github.com/prefix-dev/resolvo/pull/170))
 - *(ci)* bump actions/checkout from 4.2.2 to 5.0.0 ([#165](https://github.com/prefix-dev/resolvo/pull/165))
+
+## [0.10.1](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.10.0...resolvo-v0.10.1) - 2025-07-30
+
+### Other
+
+- strip whitespace if version set empty ([#164](https://github.com/prefix-dev/resolvo/pull/164))
+- *(ci)* bump MarcoIeni/release-plz-action from 0.5.109 to 0.5.110 ([#161](https://github.com/prefix-dev/resolvo/pull/161))
+- *(ci)* bump prefix-dev/setup-pixi from 0.8.12 to 0.8.14 ([#160](https://github.com/prefix-dev/resolvo/pull/160))
 
 ## [0.10.0](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.9.1...resolvo-v0.10.0) - 2025-07-23
 


### PR DESCRIPTION
The v0.10.1 release commit prepended its entry without removing the old header, leaving a duplicate `# Changelog`/`## [Unreleased]` block in the middle of the file. Subsequent releases (0.10.2, 0.10.3) inserted their entries below that second header, stranding the 0.10.1 entry above the duplicate and out of chronological order.

Remove the duplicated header and move 0.10.1 back between 0.10.2 and 0.10.0 so entries are in reverse-chronological order.