### PR TITLE
fix: resize name_activity for virtual provides candidates

### DIFF
--- a/src/solver/encoding.rs
+++ b/src/solver/encoding.rs
@@ -631,6 +631,13 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
     /// see [`Self::forbid_seen`] for why globally-deduplicating is safe.
     fn register_forbid_target(&mut self, name_id: NameId, variable: VariableId) {
         if self.forbid_seen.insert(variable) {
+            // Ensure name_activity covers this name_id. Candidates found via
+            // virtual provides may have a solvable_name() that differs from
+            // the queried package name, so on_candidates_available may never
+            // have resized for it.
+            if self.state.name_activity.len() <= name_id.to_usize() {
+                self.state.name_activity.resize(name_id.to_usize() + 1, 0.0);
+            }
             self.pending_forbid_clauses
                 .entry(name_id)
                 .or_default()


### PR DESCRIPTION
When a `DependencyProvider` uses virtual provides (solvable A provides capability B),` get_candidates("B")` returns solvable A whose `solvable_name()` is "A" — a different `NameId`. The name_activity vec was only resized in `on_candidates_available` for the queried name ("B"), never for the candidate's own name ("A"). During clause learning, `solvable_name()` returns the candidate's own `NameId`, causing an index-out-of-bounds panic.

Resize `name_activity` in `register_forbid_target`, which is the first place the encoder encounters a candidate's own NameId when building mutual-exclusivity constraints.