### PR TITLE
Fix panic in add_pending_forbid_clauses during conflict detection

### DIFF
--- a/src/solver/encoding.rs
+++ b/src/solver/encoding.rs
@@ -682,9 +682,14 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
                     ) {
                         (Some(false), None) => Some(literal_b),
                         (None, Some(false)) => Some(literal_a),
-                        (Some(false), Some(false)) => unreachable!(
-                            "both literals cannot be false as that would be a conflict"
-                        ),
+                        (Some(false), Some(false)) => {
+                            // Both solvables are already decided true, but the
+                            // forbid clause that would have prevented this didn't
+                            // exist yet (it's being created right now). Report it
+                            // as a conflict so the solver can backtrack.
+                            self.conflicting_clauses.push(clause_id);
+                            return;
+                        }
                         _ => None,
                     };
                     if let Some(literal) = set_literal {

--- a/tests/solver/main.rs
+++ b/tests/solver/main.rs
@@ -736,6 +736,34 @@ fn test_solve_with_additional() {
         "###);
 }
 
+/// Test that a soft requirement which conflicts with the hard solution is
+/// handled correctly when forbid clauses are created lazily.
+///
+/// Only a=1 matches the hard requirement. The soft requirement a=2 has a
+/// circular dependency on "a", so encoding it registers both a=1 and a=2 as
+/// forbid targets after both are already decided true. The solver should
+/// detect the conflict and exclude a=2 from the solution.
+#[test]
+fn test_solve_with_soft_requirement_forbid_clause_conflict() {
+    let mut provider = BundleBoxProvider::from_packages(&[("a", 1, vec![]), ("a", 2, vec!["a"])]);
+
+    // Only a=1 matches the hard requirement, so a=2 is never a matching
+    // candidate during the hard solve and no forbid clause is created.
+    let requirements = provider.requirements(&["a 1..2"]);
+    let extra_solvables = [provider.solvable_id("a", 2)];
+
+    let mut solver = Solver::new(provider);
+    let problem = Problem::new()
+        .requirements(requirements)
+        .soft_requirements(extra_solvables);
+    let solved = solver.solve(problem).unwrap();
+
+    let result = transaction_to_string(solver.provider(), &solved);
+    assert_snapshot!(result, @r###"
+    a=1
+    "###);
+}
+
 #[test]
 fn test_solve_with_additional_with_constrains() {
     let mut provider = BundleBoxProvider::from_packages(&[


### PR DESCRIPTION
Forbid-multiple clauses (which enforce "at most one version of a package") are created lazily as solvables become reachable. When run_sat() decides a solvable true and then encodes its dependencies, add_pending_forbid_clauses may discover that another solvable for the same package name was already decided true — but the forbid clause between them didn't exist yet to prevent it.

The old code hit unreachable!() in this case. Handle it as a normal conflict instead, so the solver can backtrack and try alternatives.

This is triggered by soft_requirements: the hard solve installs version A, then run_sat for a soft requirement decides version B true. During encoding of B, the forbid clause between A and B is finally created, at which point both are already true.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>