### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.10.4...resolvo-v0.11.0) - 2026-06-12
+
+### Fixed
+
+- don't merge conflict nodes with distinct requirements ([#233](https://github.com/prefix-dev/resolvo/pull/233))
+
+### Other
+
+- replace RELEASE_PLZ_TOKEN with octo-sts ([#240](https://github.com/prefix-dev/resolvo/pull/240))
+- defer candidate loading for conditional requirements ([#237](https://github.com/prefix-dev/resolvo/pull/237))
+- incremental work queue for decide() ([#238](https://github.com/prefix-dev/resolvo/pull/238))
+- encode shared constraints with an auxiliary variable per version set ([#236](https://github.com/prefix-dev/resolvo/pull/236))
+- *(ci)* bump actions/checkout from 6.0.2 to 6.0.3 ([#235](https://github.com/prefix-dev/resolvo/pull/235))
+- Fix panic in add_pending_forbid_clauses during conflict detection ([#231](https://github.com/prefix-dev/resolvo/pull/231))
+- [**breaking**] add explicit layout of externally provided ids ([#224](https://github.com/prefix-dev/resolvo/pull/224))
+
 ## [0.10.4](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.10.3...resolvo-v0.10.4) - 2026-06-02
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resolvo"
-version = "0.10.4"
+version = "0.11.0"
 dependencies = [
  "ahash",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cpp", "tools/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.4"
+version = "0.11.0"
 authors = [
     "Adolfo Ochagavía <github@adolfo.ochagavia.nl>",
     "Bas Zalmstra <zalmstra.bas@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `resolvo`: 0.10.4 -> 0.11.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.0](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.10.4...resolvo-v0.11.0) - 2026-06-12

### Fixed

- don't merge conflict nodes with distinct requirements ([#233](https://github.com/prefix-dev/resolvo/pull/233))

### Other

- replace RELEASE_PLZ_TOKEN with octo-sts ([#240](https://github.com/prefix-dev/resolvo/pull/240))
- defer candidate loading for conditional requirements ([#237](https://github.com/prefix-dev/resolvo/pull/237))
- incremental work queue for decide() ([#238](https://github.com/prefix-dev/resolvo/pull/238))
- encode shared constraints with an auxiliary variable per version set ([#236](https://github.com/prefix-dev/resolvo/pull/236))
- *(ci)* bump actions/checkout from 6.0.2 to 6.0.3 ([#235](https://github.com/prefix-dev/resolvo/pull/235))
- Fix panic in add_pending_forbid_clauses during conflict detection ([#231](https://github.com/prefix-dev/resolvo/pull/231))
- [**breaking**] add explicit layout of externally provided ids ([#224](https://github.com/prefix-dev/resolvo/pull/224))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).