### PR TITLE
fix: don't merge conflict nodes with distinct requirements

### DIFF
--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -440,14 +440,16 @@ impl<S: SolverId> ConflictGraph<S> {
                 | ConflictNode::Excluded(_) => continue,
             };
 
+            // Candidates that require different version sets stay separate so each
+            // distinct requirement is reported to the user (conda/rattler#2476).
             let predecessors: Vec<_> = graph
                 .edges_directed(node_id, Direction::Incoming)
-                .map(|e| e.source())
+                .map(|e| (e.weight().try_requires(), e.source()))
                 .sorted_unstable()
                 .collect();
             let successors: Vec<_> = graph
                 .edges(node_id)
-                .map(|e| e.target())
+                .map(|e| (e.weight().try_requires(), e.target()))
                 .sorted_unstable()
                 .collect();
 

--- a/tests/solver/main.rs
+++ b/tests/solver/main.rs
@@ -450,6 +450,20 @@ fn test_unsat_no_candidates_for_child_2() {
     insta::assert_snapshot!(error);
 }
 
+// Versions requiring different versions of a missing dependency are each
+// reported (conda/rattler#2476).
+#[test]
+fn test_unsat_no_candidates_distinct_requirements() {
+    let provider = BundleBoxProvider::from_packages(&[
+        ("a", 1, vec!["b 41..42"]),
+        ("a", 2, vec!["b 41..42"]),
+        ("a", 3, vec!["b 42..43"]),
+        ("a", 4, vec!["b 43..44"]),
+    ]);
+    let error = solve_unsat(provider, &["a"]);
+    insta::assert_snapshot!(error);
+}
+
 #[test]
 fn test_unsat_missing_top_level_dep_1() {
     let provider = BundleBoxProvider::from_packages(&[("asdf", 1, vec![])]);

--- a/tests/solver/snapshots/solver__unsat_no_candidates_distinct_requirements.snap
+++ b/tests/solver/snapshots/solver__unsat_no_candidates_distinct_requirements.snap
@@ -1,0 +1,11 @@
+---
+source: tests/solver/main.rs
+expression: error
+---
+a * cannot be installed because there are no viable options:
+├─ a 4 would require
+│  └─ b >=43, <44, for which no candidates were found.
+├─ a 3 would require
+│  └─ b >=42, <43, for which no candidates were found.
+└─ a 1 | 2 would require
+   └─ b >=41, <42, for which no candidates were found.


### PR DESCRIPTION
When an environment cannot be solved, several versions of a package that depend on different versions of a missing dependency were grouped together and only one of their requirements was shown. This hid the other requirements and made the error misleading.

This change reports each distinct requirement separately, so every version range that cannot be satisfied is visible. This is similar to how micromamba reports the same situation.

This is what conda/rattler#2476 runs into: for r-ggpmisc on emscripten-wasm32 (where r-base has no builds) every version was collapsed into one line showing only an old r-base requirement, even though newer versions need newer r-base.

Result:

```
a * cannot be installed because there are no viable options:
├─ a 4 would require
│  └─ b >=43, <44, for which no candidates were found.
├─ a 3 would require
│  └─ b >=42, <43, for which no candidates were found.
└─ a 1 | 2 would require
   └─ b >=41, <42, for which no candidates were found.
```

Tested with a new snapshot covering multiple versions that require different versions of a missing dependency. All existing snapshots are unchanged.
