### PR TITLE
perf: defer candidate loading for conditional requirements

### DIFF
--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -398,7 +398,11 @@ impl<'s> SnapshotProvider<'s> {
     /// Adds another requirement that matches any version of a package.
     /// If you use "*" as the matcher, it will match any version of the package.
     pub fn add_package_requirement(&mut self, name: NameId, matcher: &str) -> VersionSetId {
-        let id = self.snapshot.version_sets.max() + self.additional_version_sets.len();
+        // Additional version sets are allocated directly after the highest
+        // index present in the snapshot. `Mapping::max()` returns the highest
+        // inserted *index* (not a count), so the first free index is one past
+        // it.
+        let id = self.snapshot.version_sets.max() + 1 + self.additional_version_sets.len();
         let package = self.package(name);
 
         let matching_candidates = package
@@ -441,8 +445,12 @@ impl<'s> SnapshotProvider<'s> {
     fn version_set(&self, version_set: VersionSetId) -> &VersionSet {
         let idx = version_set.to_index();
         let max_idx = self.snapshot.version_sets.max();
-        if idx >= max_idx {
-            &self.additional_version_sets[idx - max_idx]
+        // Indices up to and including `max_idx` belong to the snapshot;
+        // anything beyond was allocated by `add_package_requirement`. Using
+        // `>=` here would shadow the snapshot's highest-index version set
+        // with the first additional one (and panic when none was added).
+        if idx > max_idx {
+            &self.additional_version_sets[idx - max_idx - 1]
         } else {
             self.snapshot
                 .version_sets

--- a/src/solver/clause.rs
+++ b/src/solver/clause.rs
@@ -170,9 +170,12 @@ impl<N: SolverId> Clause<N> {
         condition: Option<(DisjunctionId, &[Literal])>,
         decision_tracker: &DecisionTracker,
     ) -> (Self, Option<[Literal; 2]>, bool) {
-        // It only makes sense to introduce a requires clause when the parent solvable
-        // is undecided or going to be installed
-        assert_ne!(decision_tracker.assigned_value(parent), Some(false));
+        // On the lazy-conditional path the parent may already have been
+        // propagated false by the time this clause is built (e.g. a deferred
+        // requirement whose condition fires after the parent was forbidden).
+        // The clause is currently satisfied by `¬parent`, but that assignment
+        // can be backtracked later, so the clause must still be added.
+        let parent_is_false = decision_tracker.assigned_value(parent) == Some(false);
 
         let kind = Clause::Requires(parent, condition.map(|d| d.0), requirement);
 
@@ -190,9 +193,8 @@ impl<N: SolverId> Clause<N> {
         let mut literals = condition_literals.chain(candidate_literals).peekable();
         let Some(&first_literal) = literals.peek() else {
             // If there are no candidates and there is no condition, then this clause is an
-            // assertion.
-            // There is also no conflict because we asserted above that the parent is not
-            // assigned to false yet.
+            // assertion. An assertion never conflicts: it either re-asserts an already
+            // false parent or will assign the parent false during propagation.
             return (kind, None, false);
         };
 
@@ -200,14 +202,16 @@ impl<N: SolverId> Clause<N> {
             // Watch any candidate that is not assigned to false
             Some(watched_candidate) => (kind, Some([parent.negative(), watched_candidate]), false),
 
-            // All candidates are assigned to false! Therefore, the clause conflicts with the
-            // current decisions. There are no valid watches for it at the moment, but we will
-            // assign default ones nevertheless, because they will become valid after the solver
-            // restarts.
-            None => {
-                // Try to find a condition that is not assigned to false.
-                (kind, Some([parent.negative(), first_literal]), true)
-            }
+            // All candidates are assigned to false! Unless the parent is false as well
+            // (which satisfies the clause), the clause conflicts with the current
+            // decisions. There are no valid watches for it at the moment, but we will
+            // assign default ones nevertheless, because they will become valid after the
+            // solver restarts.
+            None => (
+                kind,
+                Some([parent.negative(), first_literal]),
+                !parent_is_false,
+            ),
         }
     }
 
@@ -228,14 +232,19 @@ impl<N: SolverId> Clause<N> {
         via: VersionSetId,
         decision_tracker: &DecisionTracker,
     ) -> (Self, Option<[Literal; 2]>, bool) {
-        // It only makes sense to introduce a constrains clause when the parent solvable
-        // is undecided or going to be installed
-        assert_ne!(decision_tracker.assigned_value(parent), Some(false));
+        // On the lazy-conditional path the parent may already have been propagated
+        // false by the time this clause is built (e.g. a candidate of a deferred
+        // requirement whose dependencies are prefetched). The clause `¬parent v
+        // ¬forbidden` is then currently satisfied, but the assignment can be
+        // backtracked later, so the clause must still be added.
+        let parent_is_false = decision_tracker.assigned_value(parent) == Some(false);
 
         // If the forbidden solvable is already assigned to true, that means that there
         // is a conflict with current decisions, because it implies the parent
-        // solvable would be false (and we just asserted that it is not)
-        let conflict = decision_tracker.assigned_value(forbidden_solvable) == Some(true);
+        // solvable would be false, unless the parent already is false, which
+        // satisfies the clause.
+        let conflict =
+            !parent_is_false && decision_tracker.assigned_value(forbidden_solvable) == Some(true);
 
         (
             Clause::Constrains(parent, forbidden_solvable, via),
@@ -266,14 +275,17 @@ impl<N: SolverId> Clause<N> {
         via: VersionSetId,
         decision_tracker: &DecisionTracker,
     ) -> (Self, Option<[Literal; 2]>, bool) {
-        // It only makes sense to introduce a constrains clause when the parent
-        // solvable is undecided or going to be installed
-        assert_ne!(decision_tracker.assigned_value(parent), Some(false));
+        // On the lazy-conditional path the parent may already have been propagated
+        // false by the time this clause is built (e.g. a candidate of a deferred
+        // requirement whose dependencies are prefetched). The clause `¬parent v
+        // ¬aux` is then currently satisfied, but the assignment can be backtracked
+        // later, so the clause must still be added.
+        let parent_is_false = decision_tracker.assigned_value(parent) == Some(false);
 
         // If the auxiliary variable is already true, an excluded candidate is
-        // installed, which implies the parent solvable would be false (and we
-        // just asserted that it is not).
-        let conflict = decision_tracker.assigned_value(aux) == Some(true);
+        // installed, which implies the parent solvable would be false, unless
+        // the parent already is false, which satisfies the clause.
+        let conflict = !parent_is_false && decision_tracker.assigned_value(aux) == Some(true);
 
         (
             Clause::ConstrainsParent(parent, aux, via),
@@ -915,21 +927,30 @@ mod test {
             candidate1
         );
 
-        // Panic
+        // No conflict: all candidates are false, but the parent is false as
+        // well, which satisfies the clause. This can happen on the
+        // lazy-conditional path where clauses are built after the parent was
+        // propagated false. The clause must still be constructed because the
+        // parent's assignment can be backtracked later.
         decisions
             .try_add_decision(Decision::new(parent, false, ClauseId::install_root()), 1)
             .unwrap();
-        let panicked = std::panic::catch_unwind(|| {
-            WatchedLiterals::requires::<crate::NameId>(
-                parent,
-                VersionSetId::from_index(0).into(),
-                [candidate1, candidate2],
-                None,
-                &decisions,
-            )
-        })
-        .is_err();
-        assert!(panicked);
+        let (clause, conflict, _kind) = WatchedLiterals::requires::<crate::NameId>(
+            parent,
+            VersionSetId::from_index(0).into(),
+            [candidate1, candidate2],
+            None,
+            &decisions,
+        );
+        assert!(!conflict);
+        assert_eq!(
+            clause.as_ref().unwrap().watched_literals[0].variable(),
+            parent
+        );
+        assert_eq!(
+            clause.as_ref().unwrap().watched_literals[1].variable(),
+            candidate1
+        );
     }
 
     #[test]
@@ -976,20 +997,29 @@ mod test {
             forbidden
         );
 
-        // Panic
+        // No conflict: the forbidden solvable is installed, but the parent is
+        // false, which satisfies the clause. This can happen on the
+        // lazy-conditional path where clauses are built after the parent was
+        // propagated false. The clause must still be constructed because the
+        // parent's assignment can be backtracked later.
         decisions
             .try_add_decision(Decision::new(parent, false, ClauseId::install_root()), 1)
             .unwrap();
-        let panicked = std::panic::catch_unwind(|| {
-            WatchedLiterals::constrains::<crate::NameId>(
-                parent,
-                forbidden,
-                VersionSetId::from_index(0),
-                &decisions,
-            )
-        })
-        .is_err();
-        assert!(panicked);
+        let (clause, conflict, _kind) = WatchedLiterals::constrains::<crate::NameId>(
+            parent,
+            forbidden,
+            VersionSetId::from_index(0),
+            &decisions,
+        );
+        assert!(!conflict);
+        assert_eq!(
+            clause.as_ref().unwrap().watched_literals[0].variable(),
+            parent
+        );
+        assert_eq!(
+            clause.as_ref().unwrap().watched_literals[1].variable(),
+            forbidden
+        );
     }
 
     #[test]

--- a/src/solver/conditions.rs
+++ b/src/solver/conditions.rs
@@ -57,11 +57,26 @@
 //! We add a requires clause for each disjunction in the boolean expression. So
 //! if we have the requirement `A requires B if C or D` we add requires clause
 //! for `A requires B if C` and for `A requires B if D`.
+//!
+//! ## Lazy candidate loading
+//!
+//! To avoid fetching candidates for requirements whose condition never fires
+//! the encoder may defer encoding a conditional requirement. When the encoder
+//! reaches such a requirement and the condition does not yet hold, the
+//! requirement is stored in [`crate::solver::SolverState::deferred_requirements`]
+//! and its requirement candidates are *not* fetched. The solver loop checks
+//! after each propagation whether any deferred condition has just started to
+//! hold; if so, the corresponding entry is drained from the deferred map and
+//! the encoder builds the requires clause exactly as the eager path would
+//! have. See [`DeferredRequirement`] and [`condition_disjunct_holds`].
 
 use std::num::NonZero;
 
 use crate::solver::clause::Literal;
-use crate::{Condition, ConditionId, DenseIndex, Interner, LogicalOperator, VersionSetId};
+use crate::{
+    Condition, ConditionId, ConditionalRequirement, DenseIndex, Interner, LogicalOperator,
+    VersionSetId, internal::solver_id::SolvableIdOrRoot,
+};
 
 /// An identifier that describes a group of version sets that are combined using
 /// AND logical operators.
@@ -119,4 +134,88 @@ pub fn convert_conditions_to_dnf<I: Interner>(
             result
         }
     }
+}
+
+/// One conjunct of a deferred condition disjunct. Captures the candidates
+/// needed to decide whether the conjunct currently holds.
+#[derive(Debug, Clone)]
+pub(crate) enum DeferredConjunct<S> {
+    /// The version set has a non-empty complement (some candidates of the
+    /// package do not match the version set). The conjunct holds when any of
+    /// the matching candidates of `version_set` is positively decided.
+    Solvables {
+        /// The version set inside the condition that this conjunct represents.
+        version_set: VersionSetId,
+        /// Candidates of the package that match `version_set`.
+        matching: Vec<S>,
+    },
+    /// The version set has an empty complement: every candidate of the package
+    /// matches it. The conjunct then holds whenever any candidate of the
+    /// package is positively decided.
+    Empty {
+        /// The version set inside the condition that this conjunct represents.
+        version_set: VersionSetId,
+        /// All candidates of the package whose version set was empty-complement.
+        all_candidates: Vec<S>,
+    },
+}
+
+impl<S> DeferredConjunct<S> {
+    /// The version set inside the condition that this conjunct represents.
+    pub fn version_set(&self) -> VersionSetId {
+        match self {
+            DeferredConjunct::Solvables { version_set, .. }
+            | DeferredConjunct::Empty { version_set, .. } => *version_set,
+        }
+    }
+
+    /// Candidates whose positive decision indicates that this conjunct holds.
+    pub fn candidates(&self) -> &[S] {
+        match self {
+            DeferredConjunct::Solvables { matching, .. } => matching,
+            DeferredConjunct::Empty { all_candidates, .. } => all_candidates,
+        }
+    }
+}
+
+/// A conditional requirement whose condition did not yet hold at the moment
+/// the encoder first reached it, and whose requirement candidates were
+/// therefore not loaded eagerly.
+///
+/// Each deferred entry corresponds to a *single* disjunct of the condition's
+/// DNF (a single `requires` clause in the encoding). Once that disjunct fires
+/// the entry is drained from
+/// [`crate::solver::SolverState::deferred_requirements`] and the requires
+/// clause is built. An entry is never encoded twice: removal happens on first
+/// fire.
+#[derive(Debug)]
+pub(crate) struct DeferredRequirement<S> {
+    /// The solvable whose dependencies introduced this requirement.
+    pub solvable_id: SolvableIdOrRoot<S>,
+    /// The conditional requirement itself; carries the requirement that needs
+    /// to be encoded once the condition fires.
+    pub requirement: ConditionalRequirement,
+    /// The condition that gates the requirement. Stored for use as the key in
+    /// the deferred map and for re-querying the cache when encoding.
+    pub condition: ConditionId,
+    /// The single disjunct of the condition's DNF that gates this entry. A
+    /// conjunction of `DeferredConjunct`; the disjunct holds when every
+    /// conjunct holds (see [`condition_disjunct_holds`]).
+    pub disjunct: Vec<DeferredConjunct<S>>,
+}
+
+/// Returns true if every conjunct in `disjunct` currently holds. A conjunct
+/// holds when at least one of its `candidates()` solvables has been
+/// positively decided in `is_positively_decided`. An empty disjunct (empty
+/// conjunction) is treated as trivially holding.
+pub(crate) fn condition_disjunct_holds<S: Copy>(
+    disjunct: &[DeferredConjunct<S>],
+    mut is_positively_decided: impl FnMut(S) -> bool,
+) -> bool {
+    disjunct.iter().all(|conjunct| {
+        conjunct
+            .candidates()
+            .iter()
+            .any(|&s| is_positively_decided(s))
+    })
 }

--- a/src/solver/encoding.rs
+++ b/src/solver/encoding.rs
@@ -1,11 +1,14 @@
-use std::{any::Any, collections::VecDeque, future::ready};
+use std::{any::Any, collections::VecDeque};
 
 use super::{SolverState, clause::WatchedLiterals, conditions};
 use crate::{
     Candidates, ConditionId, ConditionalRequirement, DenseIndex, Dependencies, DependencyProvider,
     SolverCache, StringId, VariableId, VersionSetId,
     internal::{id::ClauseId, solver_id::SolvableIdOrRoot},
-    solver::{conditions::Disjunction, decision::Decision},
+    solver::{
+        conditions::{DeferredConjunct, DeferredRequirement, Disjunction},
+        decision::Decision,
+    },
     solver_id::{IdMap, IdSet},
     utils::IndexedSet,
 };
@@ -65,6 +68,10 @@ pub(crate) struct Encoder<'a, 'cache, D: DependencyProvider> {
 enum TaskResult<'a, D: DependencyProvider> {
     Dependencies(DependenciesAvailable<'a, D::SolvableId>),
     Candidates(CandidatesAvailable<'a, D>),
+    /// The condition data for a conditional requirement is available. The
+    /// encoder uses this to decide whether to load the requirement's
+    /// candidates eagerly or defer them until the condition fires.
+    ConditionData(ConditionDataAvailable<'a, D::SolvableId>),
     RequirementCandidates(RequirementCandidatesAvailable<'a, D>),
     ConstraintCandidates(ConstraintCandidatesAvailable<'a, D::SolvableId>),
 }
@@ -81,11 +88,42 @@ struct CandidatesAvailable<'a, D: DependencyProvider> {
     package_candidates: &'a Candidates<D::SolvableId>,
 }
 
+/// Result of querying the condition data for a conditional requirement. The
+/// data is split per disjunct of the condition's DNF; each disjunct carries
+/// both the matching candidates (for the fire check) and the complement
+/// candidates (for the requires-clause literals).
+struct ConditionDataAvailable<'a, S> {
+    solvable_id: SolvableIdOrRoot<S>,
+    requirement: ConditionalRequirement,
+    condition: ConditionId,
+    disjuncts: Vec<DisjunctData<'a, S>>,
+}
+
+/// One disjunct of a condition's DNF resolved against the cache: each conjunct
+/// VS has its matching candidates (used to decide if the disjunct currently
+/// holds) and its complement representation (used to build the requires
+/// clause).
+struct DisjunctData<'a, S> {
+    conjuncts: Vec<ConjunctData<'a, S>>,
+}
+
+struct ConjunctData<'a, S> {
+    /// Candidates of the package matching the conjunct's version set. Used
+    /// for the fire check; the version set itself is carried inside the
+    /// complement form below for the encoding step.
+    matching: &'a [S],
+    /// The complement form used for the requires-clause literals.
+    complement: DisjunctionComplement<'a, S>,
+}
+
 /// Result of querying candidates for a particular requirement.
 struct RequirementCandidatesAvailable<'a, D: DependencyProvider> {
     solvable_id: SolvableIdOrRoot<D::SolvableId>,
     requirement: ConditionalRequirement,
     candidates: Vec<&'a [D::SolvableId]>,
+    /// The condition data for this requirement, already filtered to the
+    /// disjuncts that should be encoded right now. For an unconditional
+    /// requirement this is `None`.
     condition: RequirementCondition<'a, D::SolvableId>,
 }
 
@@ -154,12 +192,29 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
 
     /// Encode rules and variables for the given solvables.
     pub async fn encode(
+        self,
+        solvable_ids: impl IntoIterator<Item = SolvableIdOrRoot<D::SolvableId>>,
+    ) -> Result<Vec<ClauseId>, Box<dyn Any>> {
+        self.encode_with_deferred(solvable_ids, Vec::new()).await
+    }
+
+    /// Encode rules and variables for the given solvables, additionally
+    /// processing deferred conditional requirements whose condition just
+    /// fired. Each deferred entry is encoded into a single requires clause,
+    /// fetching its requirement candidates lazily.
+    pub async fn encode_with_deferred(
         mut self,
         solvable_ids: impl IntoIterator<Item = SolvableIdOrRoot<D::SolvableId>>,
+        deferred: Vec<DeferredRequirement<D::SolvableId>>,
     ) -> Result<Vec<ClauseId>, Box<dyn Any>> {
         // Queue the initial solvables for processing.
         for solvable_id in solvable_ids {
             self.queue_solvable(solvable_id);
+        }
+
+        // Queue deferred requirements that just had their condition fire.
+        for entry in deferred {
+            self.queue_deferred_requirement(entry);
         }
 
         // Process pending work until none remains. Immediately completed
@@ -189,6 +244,7 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
         match result {
             TaskResult::Dependencies(dependencies) => self.on_dependencies_available(dependencies),
             TaskResult::Candidates(candidates) => self.on_candidates_available(candidates),
+            TaskResult::ConditionData(data) => self.on_condition_data_available(data),
             TaskResult::RequirementCandidates(candidates) => {
                 self.on_requirement_candidates_available(candidates)
             }
@@ -228,10 +284,15 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
             }
         };
 
-        // Iterate over all requirements and find out to which packages they
-        // refer. Make sure we have all candidates for a particular package.
+        // Make sure we have all candidates for each package referenced by
+        // unconditional requirements and by constraints. Packages reachable
+        // *only* through a conditional requirement are not enqueued here;
+        // their candidates are loaded lazily in the deferred path once the
+        // condition fires (see [`Self::on_condition_data_available`] and
+        // [`Self::queue_deferred_requirement`]).
         for version_set_id in requirements
             .iter()
+            .filter(|requirement| requirement.condition.is_none())
             .flat_map(|requirement| requirement.requirement.version_sets(self.cache.provider()))
             .chain(constraints.iter().copied())
         {
@@ -295,6 +356,13 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
         );
 
         let variable = self.state.variable_map.intern_solvable_or_root(solvable_id);
+
+        // Note: on the lazy-conditional path the parent may already have been
+        // propagated false (e.g. a deferred requirement whose condition fires
+        // after the parent was forbidden). The clause is still encoded: the
+        // parent's assignment can be backtracked later, and since neither the
+        // drained deferred entry nor `clauses_added_for_solvable` is revisited,
+        // skipping the clause here would lose it permanently.
 
         // Get the variables associated with the individual candidates.
         let version_set_variables = candidates
@@ -618,12 +686,37 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
         });
     }
 
-    /// Enqueues retrieving the candidates for a particular requirement. These
-    /// candidates are already filtered and sorted.
+    /// Enqueues retrieving the candidates for a particular requirement.
+    ///
+    /// For an unconditional requirement this fetches the requirement
+    /// candidates eagerly. For a conditional requirement the condition data is
+    /// fetched first; the requirement candidates are only fetched once the
+    /// encoder confirms (in [`Self::on_condition_data_available`]) that at
+    /// least one disjunct of the condition currently holds. Disjuncts that do
+    /// not yet hold are stored in
+    /// [`crate::solver::SolverState::deferred_requirements`] and encoded later
+    /// when their condition fires.
     fn queue_conditional_requirement(
         &mut self,
         solvable_id: SolvableIdOrRoot<D::SolvableId>,
         requirement: ConditionalRequirement,
+    ) {
+        match requirement.condition {
+            None => self.queue_requirement_candidates(solvable_id, requirement, None),
+            Some(condition) => self.queue_condition_data(solvable_id, requirement, condition),
+        }
+    }
+
+    /// Enqueues fetching the requirement candidates for a (possibly
+    /// pre-filtered) conditional requirement and producing a
+    /// [`TaskResult::RequirementCandidates`] task result. If `condition_data`
+    /// is `Some` the requires clauses are encoded for the provided disjuncts
+    /// only.
+    fn queue_requirement_candidates(
+        &mut self,
+        solvable_id: SolvableIdOrRoot<D::SolvableId>,
+        requirement: ConditionalRequirement,
+        condition_data: RequirementCondition<'cache, D::SolvableId>,
     ) {
         let cache = self.cache;
         self.queue_future(async move {
@@ -634,42 +727,201 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
                     .map(|version_set| {
                         cache.get_or_cache_sorted_candidates_for_version_set(version_set)
                     }),
-            );
-
-            let condition_candidates = match requirement.condition {
-                Some(condition) => futures::future::try_join_all(
-                    conditions::convert_conditions_to_dnf(condition, cache.provider())
-                        .into_iter()
-                        .map(|cnf| {
-                            futures::future::try_join_all(cnf.into_iter().map(|version_set| {
-                                cache
-                                    .get_or_cache_non_matching_candidates(version_set)
-                                    .map_ok(move |matching_candidates| {
-                                        if matching_candidates.is_empty() {
-                                            DisjunctionComplement::Empty(version_set)
-                                        } else {
-                                            DisjunctionComplement::Solvables(
-                                                version_set,
-                                                matching_candidates,
-                                            )
-                                        }
-                                    })
-                            }))
-                        }),
-                )
-                .map_ok(move |dnf| Some((condition, dnf)))
-                .left_future(),
-                None => ready(Ok(None)).right_future(),
-            };
-
-            let (candidates, condition) = futures::try_join!(candidates, condition_candidates)?;
+            )
+            .await?;
 
             Ok(TaskResult::RequirementCandidates(
                 RequirementCandidatesAvailable {
                     solvable_id,
                     requirement,
                     candidates,
+                    condition: condition_data,
+                },
+            ))
+        });
+    }
+
+    /// Enqueues fetching the condition data (matching + complement candidates
+    /// per disjunct conjunct VS) for a conditional requirement. The fetch
+    /// targets only the *condition*'s packages; the requirement's candidates
+    /// are not fetched at this point, which is the entire purpose of the lazy
+    /// path.
+    fn queue_condition_data(
+        &mut self,
+        solvable_id: SolvableIdOrRoot<D::SolvableId>,
+        requirement: ConditionalRequirement,
+        condition: ConditionId,
+    ) {
+        let cache = self.cache;
+        self.queue_future(async move {
+            let dnf = conditions::convert_conditions_to_dnf(condition, cache.provider());
+            let disjuncts = futures::future::try_join_all(dnf.into_iter().map(|cnf| {
+                futures::future::try_join_all(cnf.into_iter().map(|version_set| async move {
+                    let (matching, non_matching) = futures::try_join!(
+                        cache.get_or_cache_matching_candidates(version_set),
+                        cache.get_or_cache_non_matching_candidates(version_set),
+                    )?;
+                    let complement = if non_matching.is_empty() {
+                        DisjunctionComplement::Empty(version_set)
+                    } else {
+                        DisjunctionComplement::Solvables(version_set, non_matching)
+                    };
+                    Ok::<_, Box<dyn Any>>(ConjunctData {
+                        matching,
+                        complement,
+                    })
+                }))
+                .map_ok(|conjuncts| DisjunctData { conjuncts })
+            }))
+            .await?;
+
+            Ok(TaskResult::ConditionData(ConditionDataAvailable {
+                solvable_id,
+                requirement,
+                condition,
+                disjuncts,
+            }))
+        });
+    }
+
+    /// Called when the condition data for a conditional requirement has been
+    /// resolved. Decides which disjuncts of the condition currently hold; for
+    /// each holding disjunct the encoder will fetch the requirement
+    /// candidates and emit the requires clause eagerly, and for each
+    /// non-holding disjunct an entry is pushed onto
+    /// [`crate::solver::SolverState::deferred_requirements`].
+    fn on_condition_data_available(
+        &mut self,
+        ConditionDataAvailable {
+            solvable_id,
+            requirement,
+            condition,
+            disjuncts,
+        }: ConditionDataAvailable<'cache, D::SolvableId>,
+    ) {
+        tracing::trace!(
+            "condition data available for {} (condition: {:?})",
+            requirement.requirement.display(self.cache.provider()),
+            condition,
+        );
+
+        // Partition disjuncts into "firing now" (encode eagerly) and "deferred"
+        // (push onto the deferred map).
+        let mut fired: Vec<Vec<DisjunctionComplement<'cache, D::SolvableId>>> = Vec::new();
+        let mut deferred_entries: Vec<DeferredRequirement<D::SolvableId>> = Vec::new();
+        for disjunct in disjuncts {
+            let holds = disjunct.conjuncts.iter().all(|conjunct| {
+                conjunct
+                    .matching
+                    .iter()
+                    .any(|&s| self.state.is_positively_decided(s))
+            });
+
+            if holds {
+                fired.push(
+                    disjunct
+                        .conjuncts
+                        .into_iter()
+                        .map(|c| c.complement)
+                        .collect(),
+                );
+            } else {
+                let deferred_disjunct = disjunct
+                    .conjuncts
+                    .iter()
+                    .map(|conjunct| match conjunct.complement {
+                        DisjunctionComplement::Solvables(version_set, _) => {
+                            DeferredConjunct::Solvables {
+                                version_set,
+                                matching: conjunct.matching.to_vec(),
+                            }
+                        }
+                        DisjunctionComplement::Empty(version_set) => DeferredConjunct::Empty {
+                            version_set,
+                            all_candidates: conjunct.matching.to_vec(),
+                        },
+                    })
+                    .collect();
+                deferred_entries.push(DeferredRequirement {
+                    solvable_id,
+                    requirement,
                     condition,
+                    disjunct: deferred_disjunct,
+                });
+            }
+        }
+
+        for entry in deferred_entries {
+            self.state.push_deferred(entry);
+        }
+
+        if !fired.is_empty() {
+            // The requirement is now being encoded; make sure its referenced
+            // packages have their candidates available so that locked /
+            // excluded clauses are emitted as on the eager path.
+            for version_set in requirement.requirement.version_sets(self.cache.provider()) {
+                let package_name = self.cache.provider().version_set_name(version_set);
+                self.queue_package(package_name);
+            }
+            self.queue_requirement_candidates(solvable_id, requirement, Some((condition, fired)));
+        }
+    }
+
+    /// Enqueues the future that fetches requirement candidates for a deferred
+    /// requirement and emits a single requires clause for the disjunct that
+    /// just fired. Used during the solver loop's drain step.
+    fn queue_deferred_requirement(&mut self, deferred: DeferredRequirement<D::SolvableId>) {
+        let DeferredRequirement {
+            solvable_id,
+            requirement,
+            condition,
+            disjunct,
+        } = deferred;
+        let cache = self.cache;
+
+        // The requirement is now being encoded; make sure its referenced
+        // packages have their candidates available so that locked / excluded
+        // clauses are emitted as on the eager path.
+        for version_set in requirement.requirement.version_sets(cache.provider()) {
+            let package_name = cache.provider().version_set_name(version_set);
+            self.queue_package(package_name);
+        }
+
+        self.queue_future(async move {
+            // Re-fetch the complement candidates for each conjunct of the
+            // disjunct. These are cache hits because they were fetched when
+            // the requirement was first deferred.
+            let condition_data =
+                futures::future::try_join_all(disjunct.into_iter().map(|conjunct| async move {
+                    let version_set = conjunct.version_set();
+                    let non_matching = cache
+                        .get_or_cache_non_matching_candidates(version_set)
+                        .await?;
+                    let complement = if non_matching.is_empty() {
+                        DisjunctionComplement::Empty(version_set)
+                    } else {
+                        DisjunctionComplement::Solvables(version_set, non_matching)
+                    };
+                    Ok::<_, Box<dyn Any>>(complement)
+                }))
+                .await?;
+
+            let candidates = futures::future::try_join_all(
+                requirement
+                    .requirement
+                    .version_sets(cache.provider())
+                    .map(|version_set| {
+                        cache.get_or_cache_sorted_candidates_for_version_set(version_set)
+                    }),
+            )
+            .await?;
+
+            Ok(TaskResult::RequirementCandidates(
+                RequirementCandidatesAvailable {
+                    solvable_id,
+                    requirement,
+                    candidates,
+                    condition: Some((condition, vec![condition_data])),
                 },
             ))
         });

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -3,18 +3,19 @@ use std::{any::Any, fmt::Display};
 use ahash::{HashMap, HashSet};
 pub use cache::SolverCache;
 use clause::{Clause, Literal, WatchedLiterals};
-use conditions::{Disjunction, DisjunctionId};
+use conditions::{DeferredRequirement, Disjunction, DisjunctionId, condition_disjunct_holds};
 use decision::Decision;
 use decision_tracker::DecisionTracker;
 use encoding::Encoder;
+use indexmap::IndexMap;
 use itertools::Itertools;
 use variable_map::VariableMap;
 
 use watch_map::WatchMap;
 
 use crate::{
-    ConditionalRequirement, DenseIndex, Dependencies, DependencyProvider, KnownDependencies,
-    Requirement, SolvableId, VariableId, VersionSetId,
+    ConditionId, ConditionalRequirement, DenseIndex, Dependencies, DependencyProvider,
+    KnownDependencies, Requirement, SolvableId, VariableId, VersionSetId,
     conflict::Conflict,
     internal::{
         arena::Arena,
@@ -241,6 +242,20 @@ pub(crate) struct SolverState<D: DependencyProvider> {
     /// for the next decision. See [`decide_queue`].
     decide_queue: decide_queue::DecideQueue<D>,
 
+    /// Conditional requirements whose condition did not hold at the moment the
+    /// encoder reached them, and whose requirement candidates have therefore
+    /// not been fetched. Keyed by `ConditionId`; each entry is a list of
+    /// per-disjunct deferred requirements that share that condition.
+    ///
+    /// Invariant: an entry remains in this map only as long as the
+    /// corresponding requires clause has *not* been encoded. The first time a
+    /// deferred entry's disjunct fires the entry is drained and the encoder
+    /// builds its requires clause exactly as the eager path would have. Once
+    /// encoded the entry is removed; condition firings later in the solve
+    /// (after backtracking or otherwise) do not re-encode it.
+    deferred_requirements:
+        IndexMap<ConditionId, Vec<DeferredRequirement<D::SolvableId>>, ahash::RandomState>,
+
     #[cfg(feature = "diagnostics")]
     propagation_counters: PropagationCounters,
 }
@@ -266,6 +281,7 @@ impl<D: DependencyProvider> Default for SolverState<D> {
             name_activity: Default::default(),
             max_activity: 0.0,
             decide_queue: Default::default(),
+            deferred_requirements: Default::default(),
             #[cfg(feature = "diagnostics")]
             propagation_counters: Default::default(),
         }
@@ -396,6 +412,13 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
     /// Returns the number of clauses in the solver after solving.
     pub fn clause_count(&self) -> usize {
         self.state.clauses.kinds.len()
+    }
+
+    /// Total number of deferred per-disjunct conditional requirements still
+    /// waiting for their condition to fire. Useful to verify the "remove on
+    /// first fire" invariant of the lazy-conditional-candidates path.
+    pub fn deferred_requirements_count(&self) -> usize {
+        self.state.deferred_requirements_count()
     }
 
     /// Set the runtime of the solver to `runtime`.
@@ -678,30 +701,45 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
                     .map(|d| (d.variable, d.derived_from)),
             );
 
-            if new_solvables.is_empty() {
-                // If no new literals were selected this solution is complete and we can return.
+            // Also detect deferred conditional requirements whose condition
+            // has just started to hold. These have to be encoded before we can
+            // conclude the solution is complete.
+            let fired_conditions = self.state.fired_deferred_conditions();
+
+            if new_solvables.is_empty() && fired_conditions.is_empty() {
+                // If no new literals were selected and no deferred conditions
+                // fired, this solution is complete and we can return.
                 tracing::trace!(
-                    "Level {}: No new solvables selected, solution is complete",
+                    "Level {}: No new solvables or fired conditions, solution is complete",
                     level
                 );
                 return Ok(true);
             }
 
-            tracing::debug!("==== Found newly selected solvables");
-            tracing::debug!(
-                " - {}",
-                new_solvables
-                    .iter()
-                    .copied()
-                    .format_with("\n- ", |(id, derived_from), f| f(&format_args!(
-                        "{} (derived from {})",
-                        id.display(&self.state.variable_map, self.provider()),
-                        self.state.clauses.kinds[derived_from.to_index()]
-                            .display(&self.state.variable_map, self.provider()),
-                    )))
-                    .to_string()
-            );
-            tracing::debug!("====");
+            if !new_solvables.is_empty() {
+                tracing::debug!("==== Found newly selected solvables");
+                tracing::debug!(
+                    " - {}",
+                    new_solvables
+                        .iter()
+                        .copied()
+                        .format_with("\n- ", |(id, derived_from), f| f(&format_args!(
+                            "{} (derived from {})",
+                            id.display(&self.state.variable_map, self.provider()),
+                            self.state.clauses.kinds[derived_from.to_index()]
+                                .display(&self.state.variable_map, self.provider()),
+                        )))
+                        .to_string()
+                );
+                tracing::debug!("====");
+            }
+
+            if !fired_conditions.is_empty() {
+                tracing::debug!(
+                    "==== Found {} deferred condition(s) that just fired",
+                    fired_conditions.len()
+                );
+            }
 
             solvable_ids.clear();
             solvable_ids.extend(new_solvables.iter().filter_map(|(variable, _)| {
@@ -712,11 +750,17 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
                     .map(SolvableIdOrRoot::from)
             }));
 
+            // Drain the fired deferred requirements.
+            let mut deferred_to_encode = Vec::new();
+            for condition in fired_conditions {
+                deferred_to_encode.extend(self.state.drain_fired_deferred(condition));
+            }
+
             #[cfg(feature = "diagnostics")]
             let encoding_start = std::time::Instant::now();
             let conflicting_clauses = self.async_runtime.block_on(
                 Encoder::new(&mut self.state, &self.cache, root_deps, level)
-                    .encode(solvable_ids.iter().copied()),
+                    .encode_with_deferred(solvable_ids.iter().copied(), deferred_to_encode),
             )?;
             #[cfg(feature = "diagnostics")]
             {
@@ -1609,5 +1653,97 @@ impl<D: DependencyProvider> SolverState<D> {
                 None
             }
         })
+    }
+
+    /// Returns true if `solvable_id` has been assigned the value `true` in the
+    /// current decision state. A solvable that has never been interned as a
+    /// variable is treated as not decided.
+    pub(crate) fn is_positively_decided(&self, solvable_id: D::SolvableId) -> bool {
+        match self.variable_map.lookup_solvable(solvable_id) {
+            Some(variable) => self.decision_tracker.assigned_value(variable) == Some(true),
+            None => false,
+        }
+    }
+
+    /// Returns the `ConditionId`s of deferred requirements whose gating
+    /// disjunct currently holds. Entries are reported in insertion order so
+    /// that drain order is deterministic.
+    pub(crate) fn fired_deferred_conditions(&self) -> Vec<ConditionId> {
+        self.deferred_requirements
+            .iter()
+            .filter(|(_, entries)| {
+                entries.iter().any(|entry| {
+                    condition_disjunct_holds(&entry.disjunct, |s| self.is_positively_decided(s))
+                })
+            })
+            .map(|(condition, _)| *condition)
+            .collect()
+    }
+
+    /// Drain deferred requirements for `condition` whose disjunct currently
+    /// holds. Removed entries are returned. If, after draining, no entries
+    /// remain for `condition`, the key is removed from the map entirely.
+    pub(crate) fn drain_fired_deferred(
+        &mut self,
+        condition: ConditionId,
+    ) -> Vec<DeferredRequirement<D::SolvableId>> {
+        // Decide first which indices fire while only holding immutable
+        // borrows of the state, then mutate the deferred map. The two-pass
+        // structure avoids overlapping mutable and immutable borrows of
+        // `self`.
+        let fire_mask: Vec<bool> = match self.deferred_requirements.get(&condition) {
+            Some(entries) => entries
+                .iter()
+                .map(|entry| {
+                    condition_disjunct_holds(&entry.disjunct, |s| self.is_positively_decided(s))
+                })
+                .collect(),
+            None => return Vec::new(),
+        };
+
+        let entries = self
+            .deferred_requirements
+            .get_mut(&condition)
+            .expect("entries existed in the immutable phase");
+        let mut fired = Vec::new();
+        // Use `remove` instead of `swap_remove`: it preserves the relative
+        // order of the entries that stay in the deferred map, so that any
+        // subsequent drain visits them in the same order regardless of how
+        // many drains have happened before. Walk indices in reverse so each
+        // `remove` does not shift the indices we still need to inspect.
+        for (i, _) in fire_mask
+            .iter()
+            .enumerate()
+            .rev()
+            .filter(|&(_, &did_fire)| did_fire)
+        {
+            fired.push(entries.remove(i));
+        }
+
+        if entries.is_empty() {
+            self.deferred_requirements.swap_remove(&condition);
+        }
+
+        // We pushed in reverse order; restore insertion order for determinism.
+        fired.reverse();
+        fired
+    }
+
+    /// Register a new deferred requirement. Used by the encoder when it
+    /// detects that a conditional requirement's disjunct does not yet hold.
+    pub(crate) fn push_deferred(&mut self, entry: DeferredRequirement<D::SolvableId>) {
+        self.deferred_requirements
+            .entry(entry.condition)
+            .or_default()
+            .push(entry);
+    }
+
+    /// Total number of deferred per-disjunct entries still waiting for their
+    /// condition to fire.
+    pub(crate) fn deferred_requirements_count(&self) -> usize {
+        self.deferred_requirements
+            .values()
+            .map(|entries| entries.len())
+            .sum()
     }
 }

--- a/src/solver/variable_map.rs
+++ b/src/solver/variable_map.rs
@@ -82,6 +82,13 @@ impl<N: SolverId, S: SolverId> VariableMap<N, S> {
         variable_id
     }
 
+    /// Looks up the variable for a solvable without allocating one. Returns
+    /// `None` if no variable has been allocated for this solvable yet, which
+    /// implies the solvable has not been decided.
+    pub fn lookup_solvable(&self, solvable_id: S) -> Option<VariableId> {
+        self.solvable_to_variable.get(solvable_id)
+    }
+
     #[cfg(feature = "diagnostics")]
     pub fn count(&self) -> usize {
         self.origins.len()

--- a/tests/solver/bundle_box/mod.rs
+++ b/tests/solver/bundle_box/mod.rs
@@ -40,8 +40,8 @@ use itertools::Itertools;
 pub use pack::Pack;
 use resolvo::{
     Candidates, Condition, ConditionId, ConditionalRequirement, Dependencies, DependencyProvider,
-    Interner, KnownDependencies, NameId, SolvableId, SolverCache, StringId, VersionSetId,
-    VersionSetUnionId, snapshot::DependencySnapshot, utils::Pool,
+    HintDependenciesAvailable, Interner, KnownDependencies, NameId, SolvableId, SolverCache,
+    StringId, VersionSetId, VersionSetUnionId, snapshot::DependencySnapshot, utils::Pool,
 };
 pub use spec::Spec;
 use version_ranges::Ranges;
@@ -61,6 +61,11 @@ pub struct BundleBoxProvider {
     concurrent_requests: Arc<AtomicUsize>,
     pub concurrent_requests_max: Rc<Cell<usize>>,
     pub sleep_before_return: bool,
+    /// When set, candidates are returned with
+    /// [`HintDependenciesAvailable::All`], which makes the solver prefetch
+    /// (and encode) the dependencies of requirement candidates as soon as the
+    /// requirement itself is encoded.
+    pub hint_dependencies_available: bool,
 
     // A mapping of packages that we have requested candidates for. This way we can keep track of
     // duplicate requests.
@@ -233,6 +238,17 @@ impl BundleBoxProvider {
     pub fn solvable_id(&self, name: impl Into<String>, version: impl Into<Pack>) -> SolvableId {
         self.intern_solvable(self.pool.intern_package_name(name.into()), version.into())
     }
+
+    /// Returns the package names for which the solver has issued a
+    /// `get_candidates` request. Used by tests that verify lazy candidate
+    /// loading does not fetch unreachable packages.
+    pub fn requested_package_names(&self) -> Vec<String> {
+        self.requested_candidates
+            .borrow()
+            .iter()
+            .map(|id| self.pool.resolve_package_name(*id).to_string())
+            .collect()
+    }
 }
 
 impl Interner for BundleBoxProvider {
@@ -343,6 +359,11 @@ impl DependencyProvider for BundleBoxProvider {
 
         let mut candidates = Candidates {
             candidates: Vec::with_capacity(package.len()),
+            hint_dependencies_available: if self.hint_dependencies_available {
+                HintDependenciesAvailable::All
+            } else {
+                HintDependenciesAvailable::None
+            },
             ..Candidates::default()
         };
         let favor = self.favored.get(package_name);

--- a/tests/solver/main.rs
+++ b/tests/solver/main.rs
@@ -859,6 +859,34 @@ fn test_snapshot() {
     assert_snapshot!(solve_for_snapshot(snapshot_provider, &[menu_req], &[]));
 }
 
+/// The snapshot's *highest-index* version set must remain resolvable through a
+/// [`resolvo::snapshot::SnapshotProvider`]. The provider used to route any
+/// index `>= Mapping::max()` to the additional version sets added via
+/// `add_package_requirement`, but `max()` is the highest inserted index (not a
+/// count), so the snapshot's last version set was shadowed by the first
+/// additional one, panicking with an out-of-bounds index when no additional
+/// set existed, and silently resolving to the wrong version set otherwise.
+#[test]
+fn test_snapshot_highest_version_set_not_shadowed() {
+    let provider = BundleBoxProvider::from_packages(&[("a", 1, vec!["b 1"]), ("b", 1, vec![])]);
+
+    let a_name_id = provider.package_name("a");
+    let snapshot = provider.into_snapshot();
+
+    let mut snapshot_provider = snapshot.provider();
+    let a_req = snapshot_provider
+        .add_package_requirement(a_name_id, "*")
+        .into();
+
+    // Solving must resolve `b 1`, the highest-index version set in the
+    // snapshot, to pull in `b`. With the shadowing bug the lookup either
+    // panicked or resolved to the additional `a *` set, dropping `b`.
+    assert_snapshot!(solve_for_snapshot(snapshot_provider, &[a_req], &[]), @r###"
+    a=1
+    b=1
+    "###);
+}
+
 #[test]
 fn test_snapshot_union_requirements() {
     let mut provider = BundleBoxProvider::from_packages(&[
@@ -1076,6 +1104,597 @@ fn test_condition_missing_requirement() {
 
     let requirements = provider.requirements(&["menu"]);
     assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @"menu=1");
+}
+
+// ---------------------------------------------------------------------------
+// Lazy conditional candidate loading
+// ---------------------------------------------------------------------------
+//
+// The tests below cover the edge cases of the lazy-conditional-candidates
+// mechanism: deferred requirements should only fetch the gated packages once
+// the condition actually fires, multi-disjunct conditions should fire
+// per-disjunct, deferral must survive backtracking, etc.
+
+/// The conditional requirement's "if C" gate never fires, so the gated package
+/// `bla` (and its dependency `dep`) should never have its candidates fetched.
+#[test]
+#[traced_test]
+fn test_lazy_conditional_skips_unreached_candidates() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("foo", 1, vec!["bla; if bar"]),
+        ("bla", 1, vec!["dep"]),
+        ("dep", 1, vec![]),
+        ("bar", 1, vec![]),
+    ]);
+
+    // We do *not* require `bar`, so the condition `if bar` never fires.
+    let requirements = provider.requirements(&["foo"]);
+    let mut solver = Solver::new(provider);
+    let problem = Problem::new().requirements(requirements);
+    let solved = solver.solve(problem).unwrap();
+    let result = transaction_to_string(solver.provider(), &solved);
+    assert_snapshot!(result, @"foo=1");
+
+    let fetched = solver.provider().requested_package_names();
+    assert!(
+        !fetched.iter().any(|name| name == "bla"),
+        "expected `bla` to remain unfetched, got {fetched:?}"
+    );
+    assert!(
+        !fetched.iter().any(|name| name == "dep"),
+        "expected `dep` to remain unfetched, got {fetched:?}"
+    );
+}
+
+/// When the condition fires the deferred clause is encoded and the gated
+/// package is fetched. Sanity check that the eager observable behaviour still
+/// produces the right solution.
+#[test]
+#[traced_test]
+fn test_lazy_conditional_fires_when_condition_holds() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("foo", 1, vec!["bla; if bar"]),
+        ("bla", 1, vec![]),
+        ("bar", 1, vec![]),
+    ]);
+
+    let requirements = provider.requirements(&["foo", "bar"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    bar=1
+    bla=1
+    foo=1
+    "###);
+}
+
+/// `a OR b` is a multi-disjunct condition. Firing only `a` should still
+/// produce a correct solution: the `a`-disjunct's clause is encoded when `a`
+/// is selected, and the `b`-disjunct stays deferred (and is never needed).
+#[test]
+#[traced_test]
+fn test_lazy_conditional_multi_disjunct_fires_per_disjunct() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("foo", 1, vec!["bla; if a or b"]),
+        ("bla", 1, vec![]),
+        ("a", 1, vec![]),
+        ("b", 1, vec![]),
+    ]);
+
+    // Only require `a`, not `b`. The disjunct gated on `a` must fire so that
+    // `bla` is included.
+    let requirements = provider.requirements(&["foo", "a"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    a=1
+    bla=1
+    foo=1
+    "###);
+}
+
+/// Multiple `requires ... if C` for the same condition should all be encoded
+/// when `C` fires. This exercises the "Multiple conditional requirements share
+/// the same `ConditionId`" edge case.
+#[test]
+#[traced_test]
+fn test_lazy_conditional_shared_condition_fires_all() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("foo", 1, vec!["bla; if cond", "ext; if cond"]),
+        ("bla", 1, vec![]),
+        ("ext", 1, vec![]),
+        ("cond", 1, vec![]),
+    ]);
+
+    let requirements = provider.requirements(&["foo", "cond"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    bla=1
+    cond=1
+    ext=1
+    foo=1
+    "###);
+}
+
+/// When the condition fires *and* the requirement is unsolvable, the solver
+/// must report the conflict, not panic and not loop forever.
+#[test]
+#[traced_test]
+fn test_lazy_conditional_late_arriving_conflict_is_reported() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("foo", 1, vec!["bla 2; if bar"]),
+        ("bar", 1, vec![]),
+        ("bla", 1, vec![]),
+    ]);
+
+    // The condition `if bar` will fire because we require `bar`; the gated
+    // requirement asks for `bla 2` but only `bla 1` exists, so the resolution
+    // is unsolvable.
+    let requirements = provider.requirements(&["foo", "bar"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    foo * cannot be installed because there are no viable options:
+    └─ foo 1 would require
+       └─ bla >=2, <3, for which no candidates were found.
+    The following packages are incompatible
+    └─ bar * can be installed with any of the following options:
+       └─ bar 1
+    "###);
+}
+
+/// Force backtracking through a deferred conditional requirement: `b 1` forces
+/// `cond`, which fires the deferred `bla; if cond`. Then the solver finds a
+/// conflict on `bla 2` and must backtrack. After backtracking it picks `b 2`
+/// (which does not force `cond`), and the deferred clause is *already*
+/// encoded (clauses are not unlearnt). The solver must still find a solution
+/// and must not encode the deferred clause twice.
+#[test]
+#[traced_test]
+fn test_lazy_conditional_survives_backtracking() {
+    // Force the solver down a path that fires the deferred condition and
+    // then backtracks:
+    //
+    // - root requires `foo` and `cond`. `cond` is required unconditionally
+    //   so the condition `if cond` is guaranteed to fire.
+    // - `foo` has two versions; the higher (`foo=2`) carries `bla 2`
+    //   (no candidate -> conflict) in addition to the deferred `bla; if
+    //   cond`. The conflict is only discovered after the deferred clause
+    //   fires and forces a `bla` selection.
+    // - After backtracking the solver settles on `foo=1`, which only has
+    //   the deferred `bla; if cond` requirement. The deferred clause is
+    //   reused from the failed branch (CDCL does not unlearn clauses).
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("foo", 2, vec!["bla; if cond", "bla 2"]),
+        ("foo", 1, vec!["bla; if cond"]),
+        ("bla", 1, vec![]),
+        ("cond", 1, vec![]),
+    ]);
+
+    let requirements = provider.requirements(&["foo", "cond"]);
+    let mut solver = Solver::new(provider);
+    let problem = Problem::new().requirements(requirements);
+    let solved = solver.solve(problem).unwrap();
+    let result = transaction_to_string(solver.provider(), &solved);
+    assert_snapshot!(result, @r###"
+    bla=1
+    cond=1
+    foo=1
+    "###);
+
+    // The `if cond` disjunct fired (cond is required), so the deferred
+    // entry was drained. The map must be empty even though the solve went
+    // through a conflict + backtrack on `foo=2`. A future regression that
+    // accidentally re-enqueues an entry on backtrack would leave a
+    // leftover here -- this is the observable hook for the "remove on
+    // first fire" invariant.
+    assert_eq!(
+        solver.deferred_requirements_count(),
+        0,
+        "deferred entries must be drained on first fire and never re-added"
+    );
+
+    // Resolve the exact same problem on a fresh solver and record its
+    // clause count. The lazy path is deterministic, so a re-solve from
+    // scratch produces the same clauses. If the original solve's
+    // backtracking accidentally caused a double-encode of any deferred
+    // clause, its clause count would be higher than the fresh re-solve's.
+    let fresh_clauses = {
+        let mut provider = BundleBoxProvider::from_packages(&[
+            ("foo", 2, vec!["bla; if cond", "bla 2"]),
+            ("foo", 1, vec!["bla; if cond"]),
+            ("bla", 1, vec![]),
+            ("cond", 1, vec![]),
+        ]);
+        let requirements = provider.requirements(&["foo", "cond"]);
+        let mut fresh_solver = Solver::new(provider);
+        let problem = Problem::new().requirements(requirements);
+        let _ = fresh_solver.solve(problem).unwrap();
+        fresh_solver.clause_count()
+    };
+    assert_eq!(
+        solver.clause_count(),
+        fresh_clauses,
+        "clause count must match a fresh re-solve; a mismatch would mean a \
+         deferred entry was encoded more than once"
+    );
+}
+
+/// Regression test for the lazy-conditional prefetch path: a candidate of a
+/// deferred requirement can already be decided *false* by the time the
+/// condition fires. `c`'s constraint `gated 2..3` propagates `gated=1` to
+/// false as soon as `c` is installed. When `cond` is later installed, the
+/// deferred `gated; if cond` fires and the encoder loads the `gated`
+/// candidates, prefetching their dependencies (the provider hints that they
+/// are cheaply available). Encoding `gated=1`'s requires/constrains clauses
+/// while `gated=1` is false used to trip the
+/// `assert_ne!(.., Some(false))` in `WatchedLiterals::constrains` (pairwise
+/// encoding) and `WatchedLiterals::constrains_parent` (shared encoding). The
+/// clauses must be added rather than skipped: the false assignment can be
+/// backtracked later, and neither the drained deferred entry nor the
+/// prefetched solvable is ever revisited.
+#[test]
+#[traced_test]
+fn test_lazy_conditional_prefetches_forbidden_candidate() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("a", 1, vec!["gated; if cond"]),
+        ("trigger", 1, vec!["cond"]),
+        ("cond", 1, vec![]),
+        ("gated", 2, vec![]),
+        ("dep", 1, vec![]),
+        ("z", 1, vec![]),
+        ("w", 1, vec![]),
+        ("w", 2, vec![]),
+        ("w", 3, vec![]),
+        ("w", 4, vec![]),
+    ]);
+    provider.hint_dependencies_available = true;
+    // Installing `c` forbids `gated=1` through a constraint.
+    provider.add_package("c", 1.into(), &[], &["gated 2..3"]);
+    // `gated=1` carries a requirement and two constraints so that the
+    // requires path and both constrains encodings run with a false parent:
+    // `z 2..3` excludes a single candidate (pairwise `Constrains`), while
+    // `w 5..6` excludes four candidates (shared `ConstrainsParent` encoding).
+    provider.add_package("gated", 1.into(), &["dep"], &["z 2..3", "w 5..6"]);
+
+    let requirements = provider.requirements(&["c", "a", "trigger"]);
+    let mut solver = Solver::new(provider);
+    let problem = Problem::new().requirements(requirements);
+    let solved = solver.solve(problem).unwrap();
+    let result = transaction_to_string(solver.provider(), &solved);
+    assert_snapshot!(result, @r###"
+    a=1
+    c=1
+    cond=1
+    gated=2
+    trigger=1
+    "###);
+}
+
+/// `condition: None` requirements must continue to behave eagerly: the gated
+/// package should be fetched even though we never decide on it. This is the
+/// existing behaviour, kept here as a regression guard.
+#[test]
+#[traced_test]
+fn test_lazy_conditional_unconditional_unaffected() {
+    let mut provider =
+        BundleBoxProvider::from_packages(&[("foo", 1, vec!["bla"]), ("bla", 1, vec![])]);
+
+    let requirements = provider.requirements(&["foo"]);
+    let mut solver = Solver::new(provider);
+    let problem = Problem::new().requirements(requirements);
+    let solved = solver.solve(problem).unwrap();
+    let result = transaction_to_string(solver.provider(), &solved);
+    assert_snapshot!(result, @r###"
+    bla=1
+    foo=1
+    "###);
+
+    let fetched = solver.provider().requested_package_names();
+    assert!(
+        fetched.iter().any(|name| name == "bla"),
+        "unconditional requirements must still fetch their candidates; got {fetched:?}"
+    );
+}
+
+/// Empty-complement condition: `if bar` is `bar *`, whose complement is
+/// always empty (every candidate of `bar` matches `*`). The encoder relies
+/// on the at-least-one tracker for `bar` to gate the requires clause. The
+/// deferred path must agree with that semantics: the condition holds iff
+/// any candidate of `bar` is selected.
+#[test]
+#[traced_test]
+fn test_lazy_conditional_empty_complement_fires() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("foo", 1, vec!["bla; if bar"]),
+        // Multiple versions of bar: the VS `bar *` still matches all of
+        // them, so its complement is empty.
+        ("bar", 1, vec![]),
+        ("bar", 2, vec![]),
+        ("bla", 1, vec![]),
+    ]);
+
+    // With `bar` requested, the condition fires and the deferred clause is
+    // encoded.
+    let requirements = provider.requirements(&["foo", "bar"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    bar=2
+    bla=1
+    foo=1
+    "###);
+}
+
+/// Determinism: running the same problem ten times must produce the exact
+/// same solution. The deferred-requirement drain order must not depend on
+/// hash iteration.
+#[test]
+fn test_lazy_conditional_determinism() {
+    fn build_provider() -> BundleBoxProvider {
+        BundleBoxProvider::from_packages(&[
+            ("foo", 1, vec!["bla; if a", "ext; if b"]),
+            ("foo", 2, vec!["bla; if a", "ext; if b"]),
+            ("bla", 1, vec![]),
+            ("ext", 1, vec![]),
+            ("a", 1, vec![]),
+            ("b", 1, vec![]),
+        ])
+    }
+
+    let baseline = {
+        let mut provider = build_provider();
+        let requirements = provider.requirements(&["foo", "a", "b"]);
+        let mut solver = Solver::new(provider);
+        let problem = Problem::new().requirements(requirements);
+        let solved = solver.solve(problem).unwrap();
+        transaction_to_string(solver.provider(), &solved)
+    };
+
+    for _ in 0..9 {
+        let mut provider = build_provider();
+        let requirements = provider.requirements(&["foo", "a", "b"]);
+        let mut solver = Solver::new(provider);
+        let problem = Problem::new().requirements(requirements);
+        let solved = solver.solve(problem).unwrap();
+        let result = transaction_to_string(solver.provider(), &solved);
+        assert_eq!(result, baseline, "non-deterministic solve");
+    }
+}
+
+/// Multi-conjunct (`a AND b`) condition. `convert_conditions_to_dnf`
+/// distributes AND over OR, so `cond_a AND cond_b` becomes a single disjunct
+/// with two conjuncts. The lazy path's `condition_disjunct_holds` only fires
+/// when *every* conjunct in the disjunct holds.
+///
+/// Existing tests cover only single-conjunct disjuncts (`if x` or `if x or
+/// y`), leaving the `disjunct.iter().all(...)` arm of
+/// `condition_disjunct_holds` unexercised. This test fixes that gap with
+/// three sub-cases sharing the same fixture but with different root
+/// requirements.
+mod test_lazy_conditional_multi_conjunct_requires_all {
+    use super::*;
+
+    fn build_provider() -> BundleBoxProvider {
+        BundleBoxProvider::from_packages(&[
+            ("a", 1, vec!["b; if cond_a and cond_b"]),
+            ("b", 1, vec![]),
+            ("cond_a", 1, vec![]),
+            ("cond_b", 1, vec![]),
+        ])
+    }
+
+    /// Neither conjunct fires. `b` must not be in the resolution and must
+    /// not have its candidates fetched.
+    #[test]
+    #[traced_test]
+    fn neither_selected() {
+        let mut provider = build_provider();
+        let requirements = provider.requirements(&["a"]);
+        let mut solver = Solver::new(provider);
+        let problem = Problem::new().requirements(requirements);
+        let solved = solver.solve(problem).unwrap();
+        let result = transaction_to_string(solver.provider(), &solved);
+        assert_snapshot!(result, @"a=1");
+
+        let fetched = solver.provider().requested_package_names();
+        assert!(
+            !fetched.iter().any(|n| n == "b"),
+            "expected `b` to remain unfetched when neither conjunct holds, \
+             got {fetched:?}"
+        );
+        assert_eq!(
+            solver.deferred_requirements_count(),
+            1,
+            "the AND-disjunct never held, its deferred entry must remain"
+        );
+    }
+
+    /// Only the first conjunct fires. `b` must not be in the resolution and
+    /// must not have its candidates fetched: the lazy path requires *every*
+    /// conjunct of the AND-disjunct to hold.
+    #[test]
+    #[traced_test]
+    fn only_first_selected() {
+        let mut provider = build_provider();
+        let requirements = provider.requirements(&["a", "cond_a"]);
+        let mut solver = Solver::new(provider);
+        let problem = Problem::new().requirements(requirements);
+        let solved = solver.solve(problem).unwrap();
+        let result = transaction_to_string(solver.provider(), &solved);
+        assert_snapshot!(result, @r###"
+        a=1
+        cond_a=1
+        "###);
+
+        let fetched = solver.provider().requested_package_names();
+        assert!(
+            !fetched.iter().any(|n| n == "b"),
+            "expected `b` to remain unfetched when only one conjunct holds, \
+             got {fetched:?}"
+        );
+        assert_eq!(
+            solver.deferred_requirements_count(),
+            1,
+            "second conjunct (cond_b) did not hold, deferred entry must remain"
+        );
+    }
+
+    /// Both conjuncts fire. `b` must be in the resolution.
+    #[test]
+    #[traced_test]
+    fn both_selected() {
+        let mut provider = build_provider();
+        let requirements = provider.requirements(&["a", "cond_a", "cond_b"]);
+        let mut solver = Solver::new(provider);
+        let problem = Problem::new().requirements(requirements);
+        let solved = solver.solve(problem).unwrap();
+        let result = transaction_to_string(solver.provider(), &solved);
+        assert_snapshot!(result, @r###"
+        a=1
+        b=1
+        cond_a=1
+        cond_b=1
+        "###);
+
+        assert_eq!(
+            solver.deferred_requirements_count(),
+            0,
+            "both conjuncts hold, the deferred entry must have been drained"
+        );
+    }
+}
+
+/// Determinism under non-deterministic async ordering. The plain
+/// [`test_lazy_conditional_determinism`] uses the default
+/// `sleep_before_return = false`, so every `get_candidates` future resolves
+/// synchronously and ordering is trivially deterministic. This test enables
+/// `sleep_before_return = true` so each provider call awaits a 10 ms timer
+/// inside the tokio runtime, forcing the `FuturesUnordered` driving the
+/// encoder to actually interleave futures.
+///
+/// We then assert that across 10 runs of the same problem:
+/// - the resolution (the solvables list) is byte-identical, and
+/// - the sorted set of packages whose candidates were fetched
+///   (`requested_package_names`) is byte-identical.
+///
+/// The second assertion is the load-bearing one for this test: it guards the
+/// deferred-requirement drain order. A regression that drains
+/// `SolverState::deferred_requirements` by hash iteration would still yield
+/// the same final resolution (CDCL is deterministic given the same input
+/// clauses) but the *order* in which conditional packages get fetched would
+/// drift, observable here as differing `requested_package_names`.
+#[test]
+fn test_lazy_conditional_determinism_async() {
+    fn build_provider() -> BundleBoxProvider {
+        let mut p = BundleBoxProvider::from_packages(&[
+            // Multiple deferred conditional requirements sharing distinct
+            // conditions, plus an inner conditional on `bla` that only
+            // fires once `a` is selected. The graph is non-trivial enough
+            // that a buggy drain order would surface.
+            ("foo", 1, vec!["bla; if a", "ext; if b", "tail; if c"]),
+            ("foo", 2, vec!["bla; if a", "ext; if b", "tail; if c"]),
+            ("bla", 1, vec!["inner; if a"]),
+            ("ext", 1, vec![]),
+            ("tail", 1, vec![]),
+            ("inner", 1, vec![]),
+            ("a", 1, vec![]),
+            ("b", 1, vec![]),
+            ("c", 1, vec![]),
+        ]);
+        // Force every provider future to await a real timer so the encoder's
+        // `FuturesUnordered` driver actually has to interleave them.
+        p.sleep_before_return = true;
+        p
+    }
+
+    fn run() -> (String, Vec<String>) {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        let mut provider = build_provider();
+        let requirements = provider.requirements(&["foo", "a", "b", "c"]);
+        let mut solver = Solver::new(provider).with_runtime(runtime);
+        let problem = Problem::new().requirements(requirements);
+        let solved = solver.solve(problem).unwrap();
+        let result = transaction_to_string(solver.provider(), &solved);
+        let mut fetched = solver.provider().requested_package_names();
+        // Sort so the assertion targets the *set* of fetched packages,
+        // which is what determinism guarantees -- the *insertion* order
+        // into the underlying HashSet is hash-randomised and not part of
+        // the solver's contract.
+        fetched.sort();
+        (result, fetched)
+    }
+
+    let baseline = run();
+    for i in 0..9 {
+        let next = run();
+        assert_eq!(
+            next.0, baseline.0,
+            "non-deterministic resolution under async ordering at iteration {i}"
+        );
+        assert_eq!(
+            next.1, baseline.1,
+            "non-deterministic fetched-packages set under async ordering at \
+             iteration {i}"
+        );
+    }
+}
+
+/// Pin the observable semantic divergence between the lazy-conditional path
+/// and the prior eager SAT encoding.
+///
+/// Setup: `cond` has versions `1` and `2`. The condition VS `cond 2..3` matches
+/// only `cond=2`; its complement is `{cond=1}`. We externally exclude `cond=1`
+/// so the *complement* is fully decided-false, while *nothing* positively
+/// selects `cond=2`. The conditional requirement is `a` requires `b` if
+/// `cond>=2`.
+///
+/// Behaviour comparison:
+/// - **Eager (legacy) path**: emits the SAT clause `¬a v ¬C!1 v b1` (where
+///   `C!1` is the complement candidate `cond=1`). With `cond=1` excluded
+///   (decided false), `¬C!1` is satisfied, so the clause forces `b1`. `b`
+///   would appear in the resolution.
+/// - **Lazy path (current implementation)**: `condition_disjunct_holds`
+///   checks whether any **matching** candidate of the condition VS is
+///   positively decided. `cond=2` is never positively decided here, so the
+///   disjunct never holds and the deferred requirement never gets encoded.
+///   `b` is therefore absent from the resolution.
+///
+/// The lazy semantics align with what a human would expect from "if `cond>=2`
+/// is selected": exclusion of `cond=1` is not the same as selection of
+/// `cond=2`.
+///
+/// This test pins the lazy behaviour so any future regression that re-derives
+/// the eager semantics fails loudly.
+#[test]
+#[traced_test]
+fn test_lazy_conditional_externally_excluded_complement_does_not_fire() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("a", 1, vec!["b; if cond 2..3"]),
+        ("b", 1, vec![]),
+        ("cond", 1, vec![]),
+        ("cond", 2, vec![]),
+    ]);
+    // Externally reject the *complement* candidate `cond=1`. Nothing forces
+    // `cond=2` to be selected; the only requirement is on `a`.
+    provider.exclude("cond", 1, "it is externally excluded");
+
+    let requirements = provider.requirements(&["a"]);
+    let mut solver = Solver::new(provider);
+    let problem = Problem::new().requirements(requirements);
+    let solved = solver.solve(problem).unwrap();
+    let result = transaction_to_string(solver.provider(), &solved);
+
+    // `b` must NOT appear in the resolution: the lazy path correctly sees
+    // that `cond=2` (the *matching* candidate of `cond 2..3`) is never
+    // positively decided, so the deferred requirement never fires. The
+    // legacy eager path would have included `b` here -- see the doc-comment
+    // above for the contrast.
+    assert_snapshot!(result, @"a=1");
+
+    // The deferred entry must still be sitting in the map (its disjunct
+    // never held), confirming the lazy path's predicate is what kept `b`
+    // out -- not some unrelated reason like `a` being uninstallable.
+    assert_eq!(
+        solver.deferred_requirements_count(),
+        1,
+        "the `if cond 2..3` disjunct never fired, so its deferred entry \
+         must remain"
+    );
 }
 
 #[cfg(feature = "serde")]

--- a/tools/solve-snapshot/src/main.rs
+++ b/tools/solve-snapshot/src/main.rs
@@ -37,6 +37,13 @@ struct Opts {
     #[clap(long, default_value = "0")]
     seed: u64,
 
+    /// Skip the first N problems: they are still generated (to advance the
+    /// RNG deterministically) but not solved or recorded. Combined with
+    /// `--seed S -n K+1 --skip K` this replays exactly problem K of the run
+    /// with seed S, e.g. to re-measure an outlier in isolation.
+    #[clap(long, default_value = "0")]
+    skip: usize,
+
     /// Enable tracing output (set RUST_LOG for verbosity, e.g. RUST_LOG=info)
     #[clap(long)]
     tracing: bool,
@@ -118,6 +125,10 @@ fn main() {
                 }
                 _ => unreachable!(),
             }
+        }
+
+        if i < opts.skip {
+            continue;
         }
 
         eprintln!(


### PR DESCRIPTION
## Summary

This PR makes conditional requirements lazy. Previously a conditional requirement (`pkg; if cond`) was encoded exactly like an unconditional one: its candidates were fetched, sorted, and turned into clauses at encode time, and those candidates' dependencies were fetched in turn, even when the gating condition never held at any point during the solve. The encoder now fetches only the *condition's* packages up front; the requirement's own candidates are loaded and its requires clause encoded the first time the condition actually fires.

On condition-heavy indexes most conditions never fire in a given solve, so most of that work (candidate fetching, sorting, interning, clause encoding, and the transitive dependency fan-out behind it) never happens at all.

## How it works

![Eager vs lazy encoding of a conditional requirement](https://raw.githubusercontent.com/baszalmstra/resolvo/assets/lazy-conditional-graphs/lazy-encoding-overview.svg)

A deferred entry is checked against the current assignment on every solver iteration. The first time its condition holds, it is drained and encoded; the encoded clause carries the condition literals, so it remains globally valid and never needs re-encoding, no matter how the solver backtracks afterwards:

![Lifecycle of a deferred conditional requirement](https://raw.githubusercontent.com/baszalmstra/resolvo/assets/lazy-conditional-graphs/deferral-lifecycle.svg)

## Key Changes

- Deferred conditional requirements live in a `deferred_requirements` map keyed by `ConditionId`, one entry per DNF disjunct. At the top of every `run_sat` iteration the solver checks which deferred conditions currently hold; fired entries are drained and encoded exactly as the eager path would have (the requires clause carries the condition literals, so the clause remains valid if the firing assignment is later backtracked). An entry is encoded at most once.
- Clause construction now handles parents that are already decided false. With deferral, clauses can be encoded mid-solve for a solvable that was propagated false earlier (e.g. a candidate of a deferred requirement that another package's constraint forbade before the condition fired). `WatchedLiterals::requires`/`constrains` previously asserted this never happens; they now build the clause with a correctly computed conflict flag (a false parent satisfies the clause, so it never conflicts, and the ordinary watch machinery takes over if the assignment is backtracked). Skipping the clause instead would be unsound: nothing ever revisits a drained deferred entry or an already-encoded solvable.
- `SnapshotProvider` no longer shadows the snapshot's highest-index version set with the additional version sets created by `add_package_requirement` (this made any solve touching that version set panic or resolve the wrong set).
- `tools/solve-snapshot` gains `--skip N`: skipped problems are still generated so the RNG advances deterministically, which makes `--seed S --skip K -n K+1` replay exactly problem K of a seeded run, e.g. to re-measure an outlier in isolation.

## Performance Results

Benchmarked on the conda-pypi + conda-forge snapshot (PyPI extras modelled as conditional requirements, so the workload is condition-heavy), 1000 randomized problems per seed, two seeds, identical problem sequences on both sides, 60 s timeout. Baseline is main plus the `SnapshotProvider` fix from this branch, so the harness fix does not pollute the comparison. The screening runs were core-pinned and ran in parallel; every flagged outlier was afterwards re-measured strictly sequentially on an idle machine and reproduced its timing.

| Speedup (2000 problems) | |
|--------|---------:|
| mean | **12.9×** |
| median | 141× |
| p90 | 9.4× |
| p95 | 7.3× |
| p99 | **4.7×** |
| timeouts | 1 → 1 |

| metric | main | this PR |
|---|---:|---:|
| total solve time (seed 0) | 2071.3 s | **132.3 s (−93.6%)** |
| total solve time (seed 1) | 2178.4 s | **197.3 s (−90.9%)** |
| p50 (pooled) | 3.242 s | 0.023 s |
| p90 (pooled) | 3.368 s | 0.358 s |
| p99 (pooled) | 3.961 s | 0.846 s |
| ok / unsat / timeout | 161/839/0 and 141/858/1 | identical |

![Solve duration histogram](https://raw.githubusercontent.com/baszalmstra/resolvo/assets/lazy-conditional-graphs/duration-histogram.png)

![Per-problem duration difference](https://raw.githubusercontent.com/baszalmstra/resolvo/assets/lazy-conditional-graphs/duration-diff-histogram.png)

Top 5 most-improved problems (this PR vs main):

- `asttokens[test], mypy-boto3[sns-with-docs], ipykernel` | **10.27s faster**
- `libgdal ==3.6.4 hada8d5e_2, mypy-boto3[qldb-with-docs], ...` | **7.76s faster**
- `mypy-boto3-mediastore-with-docs, mypy-boto3-neptune, ...` | **7.65s faster**
- `opentelemetry-exporter-otlp-proto-grpc[test], apache-airflow...` | **4.01s faster**
- `geotiff, ipaddr` | **3.93s faster**

There are no regressions: not one of the 2000 problems is both ≥1.5× and ≥50 ms slower, and the worst absolute slowdown over all 2000 problems is **2.2 ms** (on a 6 ms problem). The slowest solves on this branch (a ~2% tail between 0.75 s and 5.4 s) were each replayed in isolation with `--skip`: every timing reproduced, and main is 2.0-4.3× slower on those same problems. The single mutual 60 s timeout (seed 1, problem 480) flips in this branch's favor with a larger budget: this PR solves it in 196 s, main is still cancelled at 300 s.

## Correctness

- Statuses are identical on all 2000 problems (including the one timeout), and every solved problem returns the same number of records on both sides. The isolated replays match record counts as well.
- The 1000-problem depth is what surfaced the parent-already-false case: both seeds independently panicked around problem 905 in `WatchedLiterals::constrains` when a deferred condition fired after a constraint had forbidden one of the requirement's candidates. The fix is covered by a regression test that drives the exact scenario (a constraint propagates a gated candidate false before the condition fires, then the prefetch encodes that candidate's requires and constrains clauses) through a new `hint_dependencies_available` toggle on `BundleBoxProvider`; the test panics on the unfixed encoder.
- An earlier revision *skipped* requires clauses for false parents instead of encoding them. That is unsound across backtracking: the false assignment can be undone, and the skipped clause is never revisited, silently dropping a dependency edge. Both paths now always encode.
- Targeted tests pin the deferral semantics: encode-on-first-fire (and never twice, asserted via clause counts against a fresh re-solve), entries that never fire stay deferred and unfetched, drain order determinism, AND/OR condition firing, and survival of backtracking through a fired condition.
