### PR TITLE
perf: incremental work queue for decide()

### DIFF
--- a/src/requirement.rs
+++ b/src/requirement.rs
@@ -117,6 +117,24 @@ impl<V> RequirementMap<V> {
             Requirement::Union(id) => self.unions.insert(id, value),
         }
     }
+
+    #[inline]
+    pub fn get_mut(&mut self, key: Requirement) -> Option<&mut V> {
+        match key {
+            Requirement::Single(id) => self.singles.get_mut(id),
+            Requirement::Union(id) => self.unions.get_mut(id),
+        }
+    }
+
+    /// Returns a mutable reference to the value for `key`, inserting the
+    /// result of `default` first if the key has no entry yet.
+    #[inline]
+    pub fn get_or_insert_with(&mut self, key: Requirement, default: impl FnOnce() -> V) -> &mut V {
+        match key {
+            Requirement::Single(id) => self.singles.get_or_insert_with(id, default),
+            Requirement::Union(id) => self.unions.get_or_insert_with(id, default),
+        }
+    }
 }
 
 impl<V> std::ops::Index<Requirement> for RequirementMap<V> {

--- a/src/solver/decide_queue.rs
+++ b/src/solver/decide_queue.rs
@@ -1,0 +1,812 @@
+//! An incremental work queue for [`super::Solver::decide`].
+//!
+//! `decide()` must pick a candidate from a requires clause that is currently
+//! *eligible*: its parent is assigned true, its condition (if any) holds, and
+//! no candidate is assigned true yet. Only a small fraction of all requires
+//! clauses is eligible at any point, so instead of inspecting every clause on
+//! every call, this module tracks the eligible set incrementally and selects
+//! the best decision from it.
+//!
+//! - Every requires clause is registered as a [`TrackedClause`], identified
+//!   by its [`ClausePosition`]: the parent's registration index and the
+//!   clause's position in the parent's list. Both are append-only, so
+//!   positions are stable, and iterating clauses by position visits them in
+//!   a fixed, deterministic order.
+//! - [`DecideQueue::queue`] maps the position of each possibly-eligible
+//!   clause to its [`TrackedClauseId`]. It holds a *superset* of the
+//!   eligible clauses, restricted to clauses whose parent is assigned true:
+//!   clauses are removed only when an inspection in
+//!   [`DecideQueue::next_decision`] proves them ineligible, and every
+//!   assignment change that can make an unqueued clause eligible re-inserts
+//!   it through occurrence lists (see [`DecideQueue::sync`]).
+//! - [`DecideQueue::next_decision`] selects among the eligible clauses: it
+//!   takes the first eligible clause by position as the initial best and
+//!   then considers only the *hot* clauses after it. A clause replaces the
+//!   best only with strictly higher package activity; activities are
+//!   non-negative and a package that was never involved in a conflict has
+//!   activity exactly zero, so only clauses naming a package whose activity
+//!   was ever bumped (hot) can win. Hot clauses are mirrored in the much
+//!   smaller [`DecideQueue::hot_queue`].
+//!
+//! The selection heuristic lives only in `next_decision`; the
+//! heuristic-independent bookkeeping (wake-ups, caches, hot promotion) is
+//! verified on every call in debug builds by
+//! [`DecideQueue::debug_assert_invariants`], because a hole there does not
+//! crash or change solutions, it just silently degrades the search.
+
+use std::collections::BTreeMap;
+use std::ops::Bound;
+
+use ahash::HashMap;
+
+use crate::{
+    DependencyProvider, Requirement, VariableId, VersionSetId,
+    internal::{arena::Arena, id::ClauseId, small_vec::SmallVec},
+    requirement::RequirementMap,
+    solver_id::{IdMap, IdSet, SolverId},
+};
+
+use super::{
+    conditions::{Disjunction, DisjunctionId},
+    decision::Decision,
+    decision_map::DecisionMap,
+};
+
+/// Index of a [`TrackedClause`] in [`DecideQueue::clauses`].
+type TrackedClauseId = u32;
+
+/// The position of a requires clause in the queue's registration order: the
+/// parent's registration index in the high bits, the clause's position in
+/// the parent's list in the low bits. Comparing positions orders clauses by
+/// parent first and list order second, which is the order in which
+/// [`DecideQueue::next_decision`] considers them.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[repr(transparent)]
+struct ClausePosition(u64);
+
+impl ClausePosition {
+    fn new(parent_pos: usize, clause_pos: usize) -> Self {
+        assert!(
+            parent_pos < u32::MAX as usize && clause_pos < u32::MAX as usize,
+            "clause position exceeds the packed u64 layout"
+        );
+        Self((parent_pos as u64) << 32 | clause_pos as u64)
+    }
+}
+
+/// A requires clause as tracked by the queue.
+#[derive(Copy, Clone)]
+struct TrackedClause {
+    position: ClausePosition,
+    parent: VariableId,
+    requirement: Requirement,
+    condition: Option<DisjunctionId>,
+    clause_id: ClauseId,
+    /// Whether any package name in the requirement has ever had its activity
+    /// bumped. Only hot clauses can replace a running best in
+    /// [`DecideQueue::next_decision`]; cold clauses have package activity
+    /// exactly zero.
+    hot: bool,
+}
+
+/// The cached result of walking a requirement's sorted candidate lists.
+///
+/// The walk depends only on the requirement and the current assignment, so it
+/// is cached per requirement and shared by all clauses with that requirement.
+/// Package activity is *not* cached; it is read fresh during selection.
+#[derive(Copy, Clone)]
+enum RequirementState {
+    /// Unknown: not yet evaluated, or a candidate assignment changed since
+    /// the last evaluation.
+    Dirty,
+    /// A candidate is assigned true, so every clause with this requirement is
+    /// satisfied. `by` acts like a satisfying watch literal: as long as it
+    /// stays true, changes to other candidates cannot break satisfaction.
+    Satisfied { by: VariableId },
+    /// No candidate is assigned true, and `candidate` is the first undecided
+    /// candidate in walk order. `count` is the number of undecided candidates
+    /// in the version set the first undecided candidate was found in.
+    Frontier {
+        candidate: VariableId,
+        version_set: VersionSetId,
+        count: u32,
+    },
+}
+
+struct RequirementEntry {
+    state: RequirementState,
+    /// Candidate occurrences are registered on the first evaluation; most
+    /// encoded requirements belong to solvables that are never installed and
+    /// are never evaluated. Before registration the entry is permanently
+    /// dirty, so a missed wake-up cannot lose information.
+    occurrences_registered: bool,
+}
+
+/// The decision produced by [`DecideQueue::next_decision`], including the
+/// heuristic inputs for tracing.
+pub(crate) struct QueueDecision {
+    pub candidate: VariableId,
+    pub required_by: VariableId,
+    pub clause_id: ClauseId,
+    pub package_activity: f32,
+    pub candidate_count: u32,
+}
+
+#[cfg(feature = "diagnostics")]
+#[derive(Default)]
+pub(crate) struct DecideQueueCounters {
+    /// Variables routed through the occurrence lists during sync.
+    pub sync_touches: u64,
+    /// Clauses removed from the queue after an inspection proved them
+    /// ineligible.
+    pub dequeues: u64,
+    /// Clause inspections during selection.
+    pub selection_visits: u64,
+    /// Inspections of hot clauses after the initial best.
+    pub hot_visits: u64,
+    /// Requirement walks actually evaluated (cache misses).
+    pub walk_evals: u64,
+}
+
+pub(crate) struct DecideQueue<D: DependencyProvider> {
+    /// All registered requires clauses, indexed by [`TrackedClauseId`].
+    clauses: Vec<TrackedClause>,
+    /// The registration index of each parent variable: the high half of the
+    /// [`ClausePosition`]s of its clauses, assigned on first registration.
+    parent_positions: HashMap<VariableId, u32>,
+    /// Clause ids per parent registration index.
+    clauses_by_parent: Vec<Vec<TrackedClauseId>>,
+
+    /// Position -> clause id for every possibly-eligible clause, ordered so
+    /// that iteration visits clauses in their fixed selection order.
+    queue: BTreeMap<ClausePosition, TrackedClauseId>,
+    /// The subset of `queue` whose clauses are hot, maintained in lockstep.
+    hot_queue: BTreeMap<ClausePosition, TrackedClauseId>,
+
+    /// Names whose activity was ever bumped. Never shrinks: decay can bring
+    /// an activity back to zero, which only makes the hot set a conservative
+    /// superset.
+    hot_names: <D::NameId as SolverId>::Set,
+    /// Name -> clauses whose requirement mentions that name, used to promote
+    /// clauses when a name first becomes hot.
+    clauses_by_name: HashMap<D::NameId, Vec<TrackedClauseId>>,
+
+    /// Candidate variable -> requirements whose walk inspected it. Registered
+    /// lazily on a requirement's first evaluation.
+    requirements_by_candidate: HashMap<VariableId, SmallVec<Requirement>>,
+    /// Condition variable -> clauses whose condition disjunction mentions it.
+    clauses_by_condition_variable: HashMap<VariableId, Vec<TrackedClauseId>>,
+
+    /// The walk cache, one entry per requirement.
+    requirement_states: RequirementMap<RequirementEntry>,
+    /// Requirement -> clauses with that requirement, woken when the
+    /// requirement's satisfaction breaks.
+    clauses_by_requirement: RequirementMap<Vec<TrackedClauseId>>,
+
+    /// The variables of the solver's trail (the chronological assignment log
+    /// in [`super::decision_tracker::DecisionTracker`]) as they were at the
+    /// previous [`Self::sync`]. Comparing this snapshot against the current
+    /// trail tells the queue which variables changed in between.
+    mirror: Vec<VariableId>,
+
+    /// When true (the default; requires `activity_add > 0` and
+    /// `activity_decay >= 0`) the selection only visits hot clauses after the
+    /// first eligible one and may stop early on activity grounds. With
+    /// non-standard activity parameters the non-negativity argument breaks
+    /// down, so the selection visits every eligible clause instead.
+    hot_only: bool,
+
+    #[cfg(feature = "diagnostics")]
+    pub(crate) counters: DecideQueueCounters,
+}
+
+impl<D: DependencyProvider> Default for DecideQueue<D> {
+    fn default() -> Self {
+        Self {
+            clauses: Vec::new(),
+            parent_positions: HashMap::default(),
+            clauses_by_parent: Vec::new(),
+            queue: BTreeMap::new(),
+            hot_queue: BTreeMap::new(),
+            hot_names: Default::default(),
+            clauses_by_name: HashMap::default(),
+            requirements_by_candidate: HashMap::default(),
+            clauses_by_condition_variable: HashMap::default(),
+            requirement_states: RequirementMap::default(),
+            clauses_by_requirement: RequirementMap::default(),
+            mirror: Vec::new(),
+            hot_only: true,
+            #[cfg(feature = "diagnostics")]
+            counters: DecideQueueCounters::default(),
+        }
+    }
+}
+
+/// Inserts a clause into the queue (and the hot queue if it is hot), unless
+/// its parent is not currently assigned true. Filtering on the parent here
+/// keeps the constant churn of candidate variables being forbidden from ever
+/// touching the queue.
+fn enqueue_clause(
+    queue: &mut BTreeMap<ClausePosition, TrackedClauseId>,
+    hot_queue: &mut BTreeMap<ClausePosition, TrackedClauseId>,
+    clauses: &[TrackedClause],
+    map: &DecisionMap,
+    id: TrackedClauseId,
+) {
+    let clause = &clauses[id as usize];
+    if map.value(clause.parent) != Some(true) {
+        return;
+    }
+    queue.insert(clause.position, id);
+    if clause.hot {
+        hot_queue.insert(clause.position, id);
+    }
+}
+
+impl<D: DependencyProvider> DecideQueue<D> {
+    /// Configures whether the activity-based selection shortcuts are sound
+    /// for the solver's activity parameters. See [`Self::hot_only`].
+    pub(crate) fn set_standard_activity_params(&mut self, standard: bool) {
+        self.hot_only = standard;
+    }
+
+    /// Registers a newly encoded requires clause. Must be called exactly once
+    /// per requires clause, in encoding order.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn register_clause(
+        &mut self,
+        parent: VariableId,
+        requirement: Requirement,
+        condition: Option<DisjunctionId>,
+        clause_id: ClauseId,
+        names: impl IntoIterator<Item = D::NameId>,
+        disjunctions: &Arena<DisjunctionId, Disjunction>,
+        parent_value: Option<bool>,
+    ) {
+        let parent_pos = *self.parent_positions.entry(parent).or_insert_with(|| {
+            self.clauses_by_parent.push(Vec::new());
+            (self.clauses_by_parent.len() - 1) as u32
+        }) as usize;
+        let clause_pos = self.clauses_by_parent[parent_pos].len();
+        let position = ClausePosition::new(parent_pos, clause_pos);
+        let id = self.clauses.len() as TrackedClauseId;
+
+        // A union can mention the same package in several version sets;
+        // dedup so the occurrence lists hold each clause once.
+        let mut hot = false;
+        let mut seen_names: SmallVec<D::NameId> = SmallVec::empty();
+        for name in names {
+            if seen_names.as_slice().contains(&name) {
+                continue;
+            }
+            seen_names.push(name);
+            if self.hot_names.contains(name) {
+                hot = true;
+            }
+            self.clauses_by_name.entry(name).or_default().push(id);
+        }
+
+        if let Some(condition) = condition {
+            for literal in &disjunctions[condition].literals {
+                self.clauses_by_condition_variable
+                    .entry(literal.variable())
+                    .or_default()
+                    .push(id);
+            }
+        }
+
+        self.requirement_states
+            .get_or_insert_with(requirement, || RequirementEntry {
+                state: RequirementState::Dirty,
+                occurrences_registered: false,
+            });
+        self.clauses_by_requirement
+            .get_or_insert_with(requirement, Vec::new)
+            .push(id);
+
+        self.clauses_by_parent[parent_pos].push(id);
+
+        self.clauses.push(TrackedClause {
+            position,
+            parent,
+            requirement,
+            condition,
+            clause_id,
+            hot,
+        });
+
+        if parent_value == Some(true) {
+            self.queue.insert(position, id);
+            if hot {
+                self.hot_queue.insert(position, id);
+            }
+        }
+    }
+
+    /// Marks a package name as hot (its activity was bumped) and promotes the
+    /// queued clauses that mention it into the hot queue. Names never become
+    /// cold again.
+    pub(crate) fn mark_name_hot(&mut self, name: D::NameId) {
+        if !self.hot_names.insert(name) {
+            return;
+        }
+        let Some(ids) = self.clauses_by_name.get(&name) else {
+            return;
+        };
+        for &id in ids {
+            let clause = &mut self.clauses[id as usize];
+            if clause.hot {
+                continue;
+            }
+            clause.hot = true;
+            let position = clause.position;
+            if let Some(&queued) = self.queue.get(&position) {
+                self.hot_queue.insert(position, queued);
+            }
+        }
+    }
+
+    /// Brings the queue up to date with all assignment changes since the
+    /// previous call, routing every changed variable through the occurrence
+    /// lists.
+    ///
+    /// `trail` is the solver's chronological assignment log: propagation
+    /// pushes onto it and backtracking pops from it, so it only ever changes
+    /// at its end. [`Self::mirror`] holds the trail variables as of the
+    /// previous sync, and `floor` (from
+    /// [`super::decision_tracker::DecisionTracker::take_sync_floor`]) is the
+    /// lowest trail length reached since then. That splits both snapshots in
+    /// three:
+    ///
+    /// - `[..floor]` is identical in the mirror and the trail: untouched, no
+    ///   work.
+    /// - `mirror[floor..]` was popped at some point: each variable may be
+    ///   unassigned now, or reassigned at a different trail position.
+    /// - `trail[floor..]` was pushed since: newly assigned variables.
+    ///
+    /// Variables in the last two ranges are re-routed (a variable can appear
+    /// in both; routing is idempotent). An assignment that was both pushed
+    /// and popped between the two calls falls in neither range: it has no net
+    /// effect on the assignment, and the queue only compares snapshots, so it
+    /// is correct to never see it.
+    pub(crate) fn sync(&mut self, floor: usize, trail: &[Decision], map: &DecisionMap) {
+        for i in floor..self.mirror.len() {
+            let variable = self.mirror[i];
+            self.route_touched(variable, map);
+        }
+        self.mirror.truncate(floor);
+        for decision in &trail[floor..] {
+            self.mirror.push(decision.variable);
+            self.route_touched(decision.variable, map);
+        }
+    }
+
+    /// Routes one variable whose assignment may have changed through the
+    /// occurrence lists, re-inserting clauses that may have become eligible
+    /// and invalidating requirement walk caches.
+    fn route_touched(&mut self, variable: VariableId, map: &DecisionMap) {
+        #[cfg(feature = "diagnostics")]
+        {
+            self.counters.sync_touches += 1;
+        }
+
+        let Self {
+            clauses,
+            parent_positions,
+            clauses_by_parent,
+            queue,
+            hot_queue,
+            requirements_by_candidate,
+            clauses_by_condition_variable,
+            requirement_states,
+            clauses_by_requirement,
+            ..
+        } = self;
+
+        let value = map.value(variable);
+
+        // Parent wake-up: a clause can only become eligible when its parent
+        // is assigned true; any other value keeps it ineligible.
+        if value == Some(true) {
+            if let Some(&parent_pos) = parent_positions.get(&variable) {
+                for &id in &clauses_by_parent[parent_pos as usize] {
+                    enqueue_clause(queue, hot_queue, clauses, map, id);
+                }
+            }
+        }
+
+        // Candidate wake-up: invalidate the walk caches of the requirements
+        // that inspected this variable, and wake clauses whose satisfaction
+        // broke. Frontier entries are only dirtied: a frontier requirement's
+        // eligible clauses are still queued (the selection only dequeues
+        // clauses of satisfied requirements; parent and condition dequeues
+        // are woken by their own lists).
+        if let Some(requirements) = requirements_by_candidate.get(&variable) {
+            for &requirement in requirements.as_slice() {
+                let entry = requirement_states
+                    .get_mut(requirement)
+                    .expect("occurrence-registered requirement has a cache entry");
+                match entry.state {
+                    RequirementState::Dirty => {}
+                    RequirementState::Frontier { .. } => entry.state = RequirementState::Dirty,
+                    RequirementState::Satisfied { by } => {
+                        if map.value(by) == Some(true) {
+                            // The satisfying candidate is still true; the
+                            // clause stays satisfied regardless of this
+                            // variable.
+                            continue;
+                        }
+                        entry.state = RequirementState::Dirty;
+                        if let Some(woken) = clauses_by_requirement.get(requirement) {
+                            for &id in woken {
+                                enqueue_clause(queue, hot_queue, clauses, map, id);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Condition wake-up: condition literals carry polarity, so any change
+        // (in either direction) can complete an all-false condition.
+        if let Some(woken) = clauses_by_condition_variable.get(&variable) {
+            for &id in woken {
+                enqueue_clause(queue, hot_queue, clauses, map, id);
+            }
+        }
+    }
+
+    /// Evaluates a requirement through the per-requirement cache by walking
+    /// its sorted candidate lists: returns the satisfying candidate if one is
+    /// assigned true, or the first undecided candidate, its version set, and
+    /// the number of undecided candidates in that version set.
+    fn eval_requirement(
+        requirement_states: &mut RequirementMap<RequirementEntry>,
+        requirements_by_candidate: &mut HashMap<VariableId, SmallVec<Requirement>>,
+        requirement: Requirement,
+        map: &DecisionMap,
+        sorted_candidates: &RequirementMap<Vec<Vec<VariableId>>>,
+        provider: &D,
+        #[cfg(feature = "diagnostics")] counters: &mut DecideQueueCounters,
+    ) -> RequirementState {
+        let entry = requirement_states
+            .get_mut(requirement)
+            .expect("every registered clause created a cache entry");
+        if !matches!(entry.state, RequirementState::Dirty) {
+            return entry.state;
+        }
+
+        #[cfg(feature = "diagnostics")]
+        {
+            counters.walk_evals += 1;
+        }
+
+        let version_set_candidates = &sorted_candidates[requirement];
+
+        if !entry.occurrences_registered {
+            entry.occurrences_registered = true;
+            for &candidate in version_set_candidates.iter().flatten() {
+                requirements_by_candidate
+                    .entry(candidate)
+                    .or_insert_with(SmallVec::empty)
+                    .push(requirement);
+            }
+        }
+
+        let mut first: Option<(VariableId, VersionSetId, u32)> = None;
+        'walk: for (version_set, candidates) in requirement
+            .version_sets(provider)
+            .zip(version_set_candidates)
+        {
+            for &candidate in candidates {
+                match map.value(candidate) {
+                    Some(true) => {
+                        entry.state = RequirementState::Satisfied { by: candidate };
+                        break 'walk;
+                    }
+                    Some(false) => {}
+                    None => match first.as_mut() {
+                        Some((_, first_version_set, count)) => {
+                            if *first_version_set == version_set {
+                                *count += 1;
+                            }
+                        }
+                        None => first = Some((candidate, version_set, 1)),
+                    },
+                }
+            }
+        }
+
+        if matches!(entry.state, RequirementState::Dirty) {
+            let Some((candidate, version_set, count)) = first else {
+                unreachable!(
+                    "when we get here it means that all candidates have been assigned false. This should not be able to happen at this point because during propagation the solvable should have been assigned false as well."
+                )
+            };
+            entry.state = RequirementState::Frontier {
+                candidate,
+                version_set,
+                count,
+            };
+        }
+        entry.state
+    }
+
+    /// Checks whether a clause is eligible at the current assignment
+    /// snapshot. Returns the requirement frontier if it is.
+    fn inspect(
+        &mut self,
+        clause: TrackedClause,
+        map: &DecisionMap,
+        sorted_candidates: &RequirementMap<Vec<Vec<VariableId>>>,
+        disjunctions: &Arena<DisjunctionId, Disjunction>,
+        provider: &D,
+    ) -> Option<(VariableId, VersionSetId, u32)> {
+        #[cfg(feature = "diagnostics")]
+        {
+            self.counters.selection_visits += 1;
+        }
+
+        // Consider only clauses in which we have decided to install the
+        // parent solvable.
+        if map.value(clause.parent) != Some(true) {
+            return None;
+        }
+
+        // If the clause has a condition that is not yet satisfied we need to
+        // skip it.
+        if let Some(condition) = clause.condition {
+            let literals = &disjunctions[condition].literals;
+            if !literals.iter().all(|c| c.eval(map) == Some(false)) {
+                return None;
+            }
+        }
+
+        match Self::eval_requirement(
+            &mut self.requirement_states,
+            &mut self.requirements_by_candidate,
+            clause.requirement,
+            map,
+            sorted_candidates,
+            provider,
+            #[cfg(feature = "diagnostics")]
+            &mut self.counters,
+        ) {
+            RequirementState::Satisfied { .. } => None,
+            RequirementState::Frontier {
+                candidate,
+                version_set,
+                count,
+            } => Some((candidate, version_set, count)),
+            RequirementState::Dirty => {
+                unreachable!("eval_requirement never leaves the entry dirty")
+            }
+        }
+    }
+
+    /// Selects the best decision among the eligible clauses, visiting them in
+    /// position order: the first eligible clause is the initial best, and a
+    /// later clause replaces it only with strictly higher package activity
+    /// and strictly fewer remaining candidates (clauses of the root are
+    /// always preferred over the rest). Ineligible clauses reached on the way
+    /// are dequeued, which is what keeps the queue tight.
+    ///
+    /// `max_activity` must be exactly the largest activity stored in
+    /// `name_activity` (it is maintained next to the bumps and decays).
+    pub(crate) fn next_decision(
+        &mut self,
+        map: &DecisionMap,
+        sorted_candidates: &RequirementMap<Vec<Vec<VariableId>>>,
+        disjunctions: &Arena<DisjunctionId, Disjunction>,
+        name_activity: &<D::NameId as SolverId>::Map<f32>,
+        max_activity: f32,
+        provider: &D,
+    ) -> Option<QueueDecision> {
+        struct Best {
+            position: ClausePosition,
+            explicit: bool,
+            activity: f32,
+            count: u32,
+            decision: (VariableId, VariableId, ClauseId),
+        }
+
+        let hot_only = self.hot_only;
+        // Replacement requires strictly fewer candidates than the best (so a
+        // count of one is unbeatable) and, with standard activity parameters,
+        // strictly higher activity (so the global maximum is unbeatable).
+        let unbeatable =
+            |best: &Best| best.count == 1 || (hot_only && best.activity == max_activity);
+
+        // The first eligible clause in position order is the initial best.
+        // Ineligible clauses reached on the way are dequeued (amortized
+        // against their insertions).
+        let mut best: Option<Best> = None;
+        while let Some((&position, &id)) = self.queue.first_key_value() {
+            let clause = self.clauses[id as usize];
+            match self.inspect(clause, map, sorted_candidates, disjunctions, provider) {
+                None => {
+                    self.queue.pop_first();
+                    self.hot_queue.remove(&position);
+                    #[cfg(feature = "diagnostics")]
+                    {
+                        self.counters.dequeues += 1;
+                    }
+                }
+                Some((candidate, version_set, count)) => {
+                    let activity = name_activity.get(provider.version_set_name(version_set));
+                    best = Some(Best {
+                        position,
+                        explicit: clause.parent == VariableId::root(),
+                        activity,
+                        count,
+                        decision: (candidate, clause.parent, clause.clause_id),
+                    });
+                    break;
+                }
+            }
+        }
+        let mut best = best?;
+
+        // Try to replace the best with an eligible clause after it. With
+        // standard activity parameters only hot clauses can win, so only the
+        // much smaller hot queue is visited.
+        if !unbeatable(&best) {
+            let mut cursor = best.position;
+            loop {
+                let next = if hot_only {
+                    self.hot_queue
+                        .range((Bound::Excluded(cursor), Bound::Unbounded))
+                        .next()
+                } else {
+                    self.queue
+                        .range((Bound::Excluded(cursor), Bound::Unbounded))
+                        .next()
+                }
+                .map(|(&position, &id)| (position, id));
+                let Some((position, id)) = next else {
+                    break;
+                };
+                cursor = position;
+
+                let clause = self.clauses[id as usize];
+                let is_explicit = clause.parent == VariableId::root();
+
+                // Decisions on explicit requirements (clauses of the root)
+                // are preferred over non-explicit requirements; such clauses
+                // are skipped without an eligibility inspection and stay
+                // queued.
+                if best.explicit && !is_explicit {
+                    continue;
+                }
+
+                #[cfg(feature = "diagnostics")]
+                {
+                    self.counters.hot_visits += 1;
+                }
+
+                match self.inspect(clause, map, sorted_candidates, disjunctions, provider) {
+                    None => {
+                        self.queue.remove(&position);
+                        self.hot_queue.remove(&position);
+                        #[cfg(feature = "diagnostics")]
+                        {
+                            self.counters.dequeues += 1;
+                        }
+                    }
+                    Some((candidate, version_set, count)) => {
+                        let activity = name_activity.get(provider.version_set_name(version_set));
+
+                        // Prefer a higher package activity score to root out
+                        // conflicts faster, and fewer remaining candidates to
+                        // reduce backtracking. Both must improve strictly.
+                        if best.activity >= activity {
+                            continue;
+                        }
+                        if best.count <= count {
+                            continue;
+                        }
+
+                        best = Best {
+                            position,
+                            explicit: is_explicit,
+                            activity,
+                            count,
+                            decision: (candidate, clause.parent, clause.clause_id),
+                        };
+                        if unbeatable(&best) {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        let (candidate, required_by, clause_id) = best.decision;
+        Some(QueueDecision {
+            candidate,
+            required_by,
+            clause_id,
+            package_activity: best.activity,
+            candidate_count: best.count,
+        })
+    }
+
+    /// Verifies the heuristic-independent queue invariants. Called on every
+    /// `decide()` in debug builds; a violation means a wake-up, cache, or hot
+    /// promotion hole, which would otherwise only show up as silently
+    /// different decisions (the solver stays sound under any decision order).
+    ///
+    /// Must run after [`Self::sync`]; [`Self::next_decision`] only ever
+    /// dequeues ineligible clauses, so the invariants hold before and after
+    /// it.
+    #[cfg(debug_assertions)]
+    pub(crate) fn debug_assert_invariants(
+        &self,
+        map: &DecisionMap,
+        sorted_candidates: &RequirementMap<Vec<Vec<VariableId>>>,
+        disjunctions: &Arena<DisjunctionId, Disjunction>,
+        name_activity: &<D::NameId as SolverId>::Map<f32>,
+        max_activity: f32,
+        provider: &D,
+    ) {
+        // Every eligible clause is queued. Eligibility is recomputed from
+        // first principles, without the caches or the heuristic.
+        for (id, clause) in self.clauses.iter().enumerate() {
+            if map.value(clause.parent) != Some(true) {
+                continue;
+            }
+            if let Some(condition) = clause.condition {
+                let literals = &disjunctions[condition].literals;
+                if !literals.iter().all(|c| c.eval(map) == Some(false)) {
+                    continue;
+                }
+            }
+            let satisfied = sorted_candidates[clause.requirement]
+                .iter()
+                .flatten()
+                .any(|&candidate| map.value(candidate) == Some(true));
+            if satisfied {
+                continue;
+            }
+            assert!(
+                self.queue.contains_key(&clause.position),
+                "eligible requires clause {id} is not queued"
+            );
+        }
+
+        // Hot flags match the hot name set, and the hot queue mirrors the
+        // queue for hot clauses.
+        for (id, clause) in self.clauses.iter().enumerate() {
+            let should_be_hot = clause
+                .requirement
+                .version_sets(provider)
+                .any(|version_set| {
+                    self.hot_names
+                        .contains(provider.version_set_name(version_set))
+                });
+            assert_eq!(
+                clause.hot, should_be_hot,
+                "clause {id} hot flag out of sync with the hot name set"
+            );
+            if clause.hot {
+                assert_eq!(
+                    self.queue.contains_key(&clause.position),
+                    self.hot_queue.contains_key(&clause.position),
+                    "hot queue out of lockstep for clause {id}"
+                );
+            }
+        }
+
+        // The early stop relies on `max_activity` being exactly the largest
+        // stored activity. Only meaningful with standard activity parameters
+        // (the stop is disabled otherwise).
+        if self.hot_only {
+            let mut actual_max = 0.0f32;
+            name_activity.for_each(|&activity| actual_max = actual_max.max(activity));
+            assert_eq!(
+                max_activity, actual_max,
+                "max_activity diverged from the largest stored activity"
+            );
+        }
+    }
+}

--- a/src/solver/decision_tracker.rs
+++ b/src/solver/decision_tracker.rs
@@ -6,8 +6,26 @@ use crate::{VariableId, internal::id::ClauseId};
 #[derive(Default)]
 pub(crate) struct DecisionTracker {
     map: DecisionMap,
+
+    /// The *trail*: every assignment in the chronological order it was made,
+    /// both decisions and propagated assignments. Assigning pushes onto it
+    /// and backtracking pops from it, so the trail only ever changes at its
+    /// end: two snapshots of the trail always share a common prefix up to
+    /// the minimum length reached in between.
     stack: Vec<Decision>,
+
     propagate_index: usize,
+
+    /// The minimum length of `stack` since the last call to
+    /// [`Self::take_sync_floor`]: the length of the trail prefix that is
+    /// guaranteed unchanged since then. [`crate::solver::decide_queue`] keeps
+    /// a copy of the trail and uses the floor to find what changed: copied
+    /// entries at or beyond the floor have been popped at some point (their
+    /// variables may be unassigned now or reassigned elsewhere), and current
+    /// `stack` entries at or beyond it were pushed since. An assignment that
+    /// was both pushed and popped in between is in neither range; it has no
+    /// net effect, so a consumer comparing snapshots never needs to see it.
+    sync_floor: usize,
 }
 
 impl DecisionTracker {
@@ -32,6 +50,21 @@ impl DecisionTracker {
 
     pub(crate) fn stack(&self) -> impl DoubleEndedIterator<Item = Decision> + '_ {
         self.stack.iter().copied()
+    }
+
+    /// Returns the current decision stack as a slice.
+    pub(crate) fn assignments(&self) -> &[Decision] {
+        &self.stack
+    }
+
+    /// Returns the minimum trail length reached since the previous call (or
+    /// since construction) and resets the floor to the current trail length.
+    ///
+    /// The trail up to the returned floor is unchanged since the previous
+    /// call; everything a snapshot-comparing consumer has to look at lies at
+    /// or beyond it. See [`Self::sync_floor`].
+    pub(crate) fn take_sync_floor(&mut self) -> usize {
+        std::mem::replace(&mut self.sync_floor, self.stack.len())
     }
 
     pub(crate) fn level(&self, variable_id: VariableId) -> u32 {
@@ -85,6 +118,7 @@ impl DecisionTracker {
         self.map.reset(decision.variable);
 
         self.propagate_index = self.stack.len();
+        self.sync_floor = self.sync_floor.min(self.stack.len());
 
         let top_decision = self.stack.last().unwrap();
         (decision, self.map.level(top_decision.variable))
@@ -98,5 +132,54 @@ impl DecisionTracker {
         let &decision = self.stack[self.propagate_index..].iter().next()?;
         self.propagate_index += 1;
         Some(decision)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::DenseIndex;
+
+    fn var(i: usize) -> VariableId {
+        VariableId::from_index(i)
+    }
+
+    fn push(tracker: &mut DecisionTracker, i: usize, level: u32) {
+        tracker
+            .try_add_decision(Decision::new(var(i), true, ClauseId::install_root()), level)
+            .unwrap();
+    }
+
+    #[test]
+    fn take_sync_floor_tracks_minimum_stack_length() {
+        let mut tracker = DecisionTracker::default();
+        assert_eq!(tracker.take_sync_floor(), 0);
+
+        push(&mut tracker, 0, 1);
+        push(&mut tracker, 1, 2);
+        push(&mut tracker, 2, 2);
+        assert_eq!(tracker.take_sync_floor(), 0);
+
+        // An assignment made and undone between two observations cancels out:
+        // the floor only drops to the minimum length reached.
+        tracker.undo_last();
+        push(&mut tracker, 3, 2);
+        assert_eq!(tracker.take_sync_floor(), 2);
+
+        // Two undos followed by new pushes report the deepest undo.
+        tracker.undo_last();
+        tracker.undo_last();
+        push(&mut tracker, 4, 2);
+        push(&mut tracker, 5, 2);
+        assert_eq!(tracker.take_sync_floor(), 1);
+
+        // Pushes alone never lower the floor: it stays at the stack length
+        // observed by the previous take (3), not the current length (4).
+        push(&mut tracker, 6, 2);
+        assert_eq!(tracker.take_sync_floor(), 3);
+
+        // Clearing resets the floor to zero.
+        tracker.clear();
+        assert_eq!(tracker.take_sync_floor(), 0);
     }
 }

--- a/src/solver/diagnostics.rs
+++ b/src/solver/diagnostics.rs
@@ -216,6 +216,19 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
             .unwrap();
         }
 
+        let queue_counters = &self.state.decide_queue.counters;
+        writeln!(writer, "\n=== Decide Queue ===").unwrap();
+        writeln!(writer, "Sync touches:\t{}", queue_counters.sync_touches).unwrap();
+        writeln!(
+            writer,
+            "Selection visits:\t{}",
+            queue_counters.selection_visits
+        )
+        .unwrap();
+        writeln!(writer, "- Hot:\t{}", queue_counters.hot_visits).unwrap();
+        writeln!(writer, "Dequeues:\t{}", queue_counters.dequeues).unwrap();
+        writeln!(writer, "Walk evaluations:\t{}", queue_counters.walk_evals).unwrap();
+
         writeln!(writer, "\n=== Phase Timing ===").unwrap();
         writeln!(
             writer,

--- a/src/solver/encoding.rs
+++ b/src/solver/encoding.rs
@@ -404,11 +404,17 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
             );
             let clause_id = self.state.add_clause(watched_literals, kind);
 
-            self.state
-                .requires_clauses
-                .entry(variable)
-                .or_default()
-                .push((requirement.requirement, condition, clause_id));
+            let names = requirement
+                .requirement
+                .version_sets(self.cache.provider())
+                .map(|version_set| self.cache.provider().version_set_name(version_set));
+            self.state.add_requires_clause(
+                variable,
+                requirement.requirement,
+                condition,
+                clause_id,
+                names,
+            );
 
             if conflict {
                 self.conflicting_clauses.push(clause_id);

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, fmt::Display, ops::ControlFlow};
+use std::{any::Any, fmt::Display};
 
 use ahash::{HashMap, HashSet};
 pub use cache::SolverCache;
@@ -7,7 +7,6 @@ use conditions::{Disjunction, DisjunctionId};
 use decision::Decision;
 use decision_tracker::DecisionTracker;
 use encoding::Encoder;
-use indexmap::IndexMap;
 use itertools::Itertools;
 use variable_map::VariableMap;
 
@@ -33,6 +32,7 @@ mod binary_encoding;
 mod cache;
 pub(crate) mod clause;
 mod conditions;
+mod decide_queue;
 mod decision;
 mod decision_map;
 mod decision_tracker;
@@ -196,11 +196,8 @@ pub struct Solver<D: DependencyProvider, RT: AsyncRuntime = NowOrNeverRuntime> {
     activity_decay: f32,
 }
 
-type RequiresClause = (Requirement, Option<DisjunctionId>, ClauseId);
-
 pub(crate) struct SolverState<D: DependencyProvider> {
     pub(crate) clauses: Clauses<D::NameId>,
-    requires_clauses: IndexMap<VariableId, Vec<RequiresClause>, ahash::RandomState>,
     watches: WatchMap,
 
     /// A mapping from requirements to the variables that represent the
@@ -235,6 +232,15 @@ pub(crate) struct SolverState<D: DependencyProvider> {
     /// Activity score per package.
     name_activity: <D::NameId as SolverId>::Map<f32>,
 
+    /// The largest activity stored in `name_activity`, maintained bit-exactly
+    /// next to the bumps and decays. Used by the decision fold to stop early
+    /// when no remaining item can have a strictly higher activity.
+    max_activity: f32,
+
+    /// Incremental work queue that tracks which requires clauses are eligible
+    /// for the next decision. See [`decide_queue`].
+    decide_queue: decide_queue::DecideQueue<D>,
+
     #[cfg(feature = "diagnostics")]
     propagation_counters: PropagationCounters,
 }
@@ -243,7 +249,6 @@ impl<D: DependencyProvider> Default for SolverState<D> {
     fn default() -> Self {
         Self {
             clauses: Default::default(),
-            requires_clauses: Default::default(),
             watches: Default::default(),
             requirement_to_sorted_candidates: Default::default(),
             variable_map: Default::default(),
@@ -259,6 +264,8 @@ impl<D: DependencyProvider> Default for SolverState<D> {
             constrains_aux_vars: Default::default(),
             decision_tracker: Default::default(),
             name_activity: Default::default(),
+            max_activity: 0.0,
+            decide_queue: Default::default(),
             #[cfg(feature = "diagnostics")]
             propagation_counters: Default::default(),
         }
@@ -448,6 +455,13 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
     ) -> Result<Vec<D::SolvableId>, UnsolvableOrCancelled> {
         // Re-initialize the solver state.
         self.state = SolverState::default();
+
+        // The decision fold's activity-based shortcuts are only sound when
+        // activities can never become negative and cold packages stay at
+        // exactly zero.
+        self.state
+            .decide_queue
+            .set_standard_activity_params(self.activity_add > 0.0 && self.activity_decay >= 0.0);
 
         // Construct the root dependencies from the problem
         let root_dependencies = Dependencies::Known(KnownDependencies {
@@ -844,211 +858,61 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
     ///    with the least amount of possible candidates requires less
     ///    backtracking to determine unsatisfiability than a requirement with
     ///    more possible candidates.
+    ///
+    /// The selection is computed incrementally by [`decide_queue::DecideQueue`]
+    /// instead of rescanning every requires clause on every call; debug
+    /// builds verify the queue's bookkeeping invariants on every call.
     fn decide(&mut self) -> Option<(VariableId, VariableId, ClauseId)> {
-        struct PossibleDecision {
-            /// The activity of the package that is selected
-            package_activity: f32,
-
-            /// If this decision is based on a requirement that is explicitly
-            /// requested by the user.
-            is_explicit_requirement: bool,
-
-            /// The total number of possible candidates that are available for
-            /// this requirement.
-            candidate_count: u32,
-
-            /// The decision to make.
-            decision: (VariableId, VariableId, ClauseId),
-        }
-
-        let mut best_decision: Option<PossibleDecision> = None;
-        for (&solvable_id, requirements) in self.state.requires_clauses.iter() {
-            let is_explicit_requirement = solvable_id == VariableId::root();
-            if let Some(best_decision) = &best_decision {
-                // If we already have an explicit requirement, there is no need to evaluate
-                // non-explicit requirements.
-                if best_decision.is_explicit_requirement && !is_explicit_requirement {
-                    continue;
-                }
-            }
-
-            // Consider only clauses in which we have decided to install the solvable
-            if self.state.decision_tracker.assigned_value(solvable_id) != Some(true) {
-                continue;
-            }
-
-            for (deps, condition, clause_id) in requirements.iter() {
-                let mut candidate = ControlFlow::Break(());
-
-                // If the clause has a condition that is not yet satisfied we need to skip it.
-                if let Some(condition) = *condition {
-                    let literals = &self.state.disjunctions[condition].literals;
-                    if !literals.iter().all(|c| {
-                        let value = c.eval(self.state.decision_tracker.map());
-                        value == Some(false)
-                    }) {
-                        // The condition is not satisfied, skip this clause.
-                        continue;
-                    }
-                }
-
-                // Get the candidates for the individual version sets.
-                let version_set_candidates = &self.state.requirement_to_sorted_candidates[*deps];
-
-                // Iterate over all version sets in the requirement and find the first version
-                // set that we can act on, or if a single candidate (from any version set) makes
-                // the clause true.
-                //
-                // NOTE: We zip the version sets from the requirements and the variables that we
-                // previously cached. This assumes that the order of the version sets is the
-                // same in both collections.
-                for (version_set, candidates) in deps
-                    .version_sets(self.provider())
-                    .zip(version_set_candidates)
-                {
-                    // Find the first candidate that is not yet assigned a value or find the first
-                    // value that makes this clause true.
-                    candidate = candidates.iter().try_fold(
-                        match candidate {
-                            ControlFlow::Continue(x) => x,
-                            _ => None,
-                        },
-                        |first_candidate, &candidate| {
-                            let assigned_value =
-                                self.state.decision_tracker.assigned_value(candidate);
-                            ControlFlow::Continue(match assigned_value {
-                                Some(true) => {
-                                    // This candidate has already been assigned so the clause is
-                                    // already true. Skip it.
-                                    return ControlFlow::Break(());
-                                }
-                                Some(false) => {
-                                    // This candidate has already been assigned false, continue the
-                                    // search.
-                                    first_candidate
-                                }
-                                None => match first_candidate {
-                                    Some((
-                                        first_candidate,
-                                        candidate_version_set,
-                                        mut candidate_count,
-                                        package_activity,
-                                    )) => {
-                                        // We found a candidate that has not been assigned yet, but
-                                        // it is not the first candidate.
-                                        if candidate_version_set == version_set {
-                                            // Increment the candidate count if this is a candidate
-                                            // in the same version set.
-                                            candidate_count += 1u32;
-                                        }
-                                        Some((
-                                            first_candidate,
-                                            candidate_version_set,
-                                            candidate_count,
-                                            package_activity,
-                                        ))
-                                    }
-                                    None => {
-                                        // We found the first candidate that has not been assigned
-                                        // yet.
-                                        let package_activity = self
-                                            .state
-                                            .name_activity
-                                            .get(self.provider().version_set_name(version_set));
-                                        Some((candidate, version_set, 1, package_activity))
-                                    }
-                                },
-                            })
-                        },
-                    );
-
-                    // Stop searching if we found a candidate that makes the clause true.
-                    if candidate.is_break() {
-                        break;
-                    }
-                }
-
-                match candidate {
-                    ControlFlow::Break(_) => {
-                        // A candidate has been assigned true which means the clause is already
-                        // true, and we can skip it.
-                        continue;
-                    }
-                    ControlFlow::Continue(None) => {
-                        unreachable!(
-                            "when we get here it means that all candidates have been assigned false. This should not be able to happen at this point because during propagation the solvable should have been assigned false as well."
-                        )
-                    }
-                    ControlFlow::Continue(Some((
-                        candidate,
-                        _version_set_id,
-                        candidate_count,
-                        package_activity,
-                    ))) => {
-                        let decision = (candidate, solvable_id, *clause_id);
-                        best_decision = Some(match &best_decision {
-                            None => PossibleDecision {
-                                is_explicit_requirement,
-                                package_activity,
-                                candidate_count,
-                                decision,
-                            },
-                            Some(best_decision) => {
-                                // Prefer decisions on explicit requirements over non-explicit
-                                // requirements. This optimizes direct dependencies over transitive
-                                // dependencies.
-                                if best_decision.is_explicit_requirement && !is_explicit_requirement
-                                {
-                                    continue;
-                                }
-
-                                // Prefer decisions with a higher package activity score to root out
-                                // conflicts faster.
-                                if best_decision.package_activity >= package_activity {
-                                    continue;
-                                }
-
-                                if best_decision.candidate_count <= candidate_count {
-                                    continue;
-                                }
-
-                                PossibleDecision {
-                                    is_explicit_requirement,
-                                    package_activity,
-                                    candidate_count,
-                                    decision,
-                                }
-                            }
-                        })
-                    }
-                }
-            }
-        }
-
-        if let Some(PossibleDecision {
-            candidate_count,
-            package_activity,
-            decision: (candidate, _solvable_id, clause_id),
+        let provider = self.cache.provider();
+        let SolverState {
+            decide_queue,
+            decision_tracker,
+            requirement_to_sorted_candidates,
+            disjunctions,
+            name_activity,
+            max_activity,
             ..
-        }) = &best_decision
-        {
+        } = &mut self.state;
+
+        let floor = decision_tracker.take_sync_floor();
+        decide_queue.sync(
+            floor,
+            decision_tracker.assignments(),
+            decision_tracker.map(),
+        );
+        let decision = decide_queue.next_decision(
+            decision_tracker.map(),
+            requirement_to_sorted_candidates,
+            disjunctions,
+            name_activity,
+            *max_activity,
+            provider,
+        );
+
+        #[cfg(debug_assertions)]
+        decide_queue.debug_assert_invariants(
+            decision_tracker.map(),
+            requirement_to_sorted_candidates,
+            disjunctions,
+            name_activity,
+            *max_activity,
+            provider,
+        );
+
+        if let Some(decision) = &decision {
             tracing::trace!(
                 "deciding to assign {}, ({}, {} activity score, {} possible candidates)",
-                candidate.display(&self.state.variable_map, self.provider()),
-                self.state.clauses.kinds[clause_id.to_index()]
+                decision
+                    .candidate
                     .display(&self.state.variable_map, self.provider()),
-                package_activity,
-                candidate_count,
+                self.state.clauses.kinds[decision.clause_id.to_index()]
+                    .display(&self.state.variable_map, self.provider()),
+                decision.package_activity,
+                decision.candidate_count,
             );
         }
 
-        // Could not find a requirement that needs satisfying.
-        best_decision.map(
-            |PossibleDecision {
-                 decision: (candidate, required_by, via),
-                 ..
-             }| { (candidate, required_by, via) },
-        )
+        decision.map(|decision| (decision.candidate, decision.required_by, decision.clause_id))
     }
 
     /// Executes one iteration of the CDCL loop
@@ -1646,10 +1510,12 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
                 .as_solvable(&self.state.variable_map)
                 .map(|s| self.provider().solvable_name(s));
             if let Some(name_id) = name_id {
-                let activity = self.state.name_activity.get(name_id);
-                self.state
-                    .name_activity
-                    .set(name_id, activity + self.activity_add);
+                let activity = self.state.name_activity.get(name_id) + self.activity_add;
+                self.state.name_activity.set(name_id, activity);
+                if activity > self.state.max_activity {
+                    self.state.max_activity = activity;
+                }
+                self.state.decide_queue.mark_name_hot(name_id);
             }
         }
 
@@ -1687,10 +1553,34 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
         self.state.name_activity.for_each_mut(|activity| {
             *activity *= self.activity_decay;
         });
+        // The same f32 multiplication applied to the identical value keeps
+        // `max_activity` bit-exact with the largest stored activity.
+        self.state.max_activity *= self.activity_decay;
     }
 }
 
 impl<D: DependencyProvider> SolverState<D> {
+    /// Registers a newly encoded requires clause with the incremental decide
+    /// queue.
+    pub(crate) fn add_requires_clause(
+        &mut self,
+        parent: VariableId,
+        requirement: Requirement,
+        condition: Option<DisjunctionId>,
+        clause_id: ClauseId,
+        names: impl IntoIterator<Item = D::NameId>,
+    ) {
+        self.decide_queue.register_clause(
+            parent,
+            requirement,
+            condition,
+            clause_id,
+            names,
+            &self.disjunctions,
+            self.decision_tracker.assigned_value(parent),
+        );
+    }
+
     /// Allocate a clause and, if it has watched literals, register them in
     /// the [`WatchMap`].
     pub(crate) fn add_clause(

--- a/src/solver_id.rs
+++ b/src/solver_id.rs
@@ -215,6 +215,9 @@ pub trait IdMap<K, V: Copy + Default> {
     /// Dense maps visit every allocated slot. Sparse maps visit only entries
     /// that were explicitly written.
     fn for_each_mut(&mut self, visit: impl FnMut(&mut V));
+
+    /// Immutable variant of [`Self::for_each_mut`].
+    fn for_each(&self, visit: impl FnMut(&V));
 }
 
 /// A set keyed by solver IDs.
@@ -255,6 +258,10 @@ impl<K: DenseIndex, V: Copy + Default> IdMap<K, V> for Vec<V> {
     fn for_each_mut(&mut self, visit: impl FnMut(&mut V)) {
         self.iter_mut().for_each(visit);
     }
+
+    fn for_each(&self, visit: impl FnMut(&V)) {
+        self.iter().for_each(visit);
+    }
 }
 
 impl<K: DenseIndex> IdSet<K> for IndexedSet<K> {
@@ -279,6 +286,10 @@ impl<K: Eq + Hash, V: Copy + Default, S: BuildHasher> IdMap<K, V> for HashMap<K,
 
     fn for_each_mut(&mut self, visit: impl FnMut(&mut V)) {
         HashMap::values_mut(self).for_each(visit);
+    }
+
+    fn for_each(&self, visit: impl FnMut(&V)) {
+        HashMap::values(self).for_each(visit);
     }
 }
 

--- a/src/utils/mapping.rs
+++ b/src/utils/mapping.rs
@@ -76,6 +76,25 @@ impl<TId: DenseIndex, TValue> Mapping<TId, TValue> {
         previous_value
     }
 
+    /// Returns a mutable reference to the value for `id`, inserting the
+    /// result of `default` first if the slot is empty. Performs the chunk
+    /// addressing only once, unlike a `get`/`insert`/`get_mut` sequence.
+    pub fn get_or_insert_with(&mut self, id: TId, default: impl FnOnce() -> TValue) -> &mut TValue {
+        let idx = id.to_index();
+        let (chunk, offset) = Self::chunk_and_offset(idx);
+        if chunk >= self.chunks.len() {
+            self.chunks
+                .resize_with(chunk + 1, || std::array::from_fn(|_| None));
+        }
+        let slot = &mut self.chunks[chunk][offset];
+        if slot.is_none() {
+            *slot = Some(default());
+            self.len += 1;
+            self.max = self.max.max(idx);
+        }
+        slot.as_mut().expect("slot was just filled")
+    }
+
     /// Unset a specific value in the mapping, returns the previous value.
     pub fn unset(&mut self, id: TId) -> Option<TValue> {
         let idx = id.to_index();

--- a/tests/solver/decide_queue_prop.rs
+++ b/tests/solver/decide_queue_prop.rs
@@ -1,0 +1,78 @@
+//! Random dependency graphs (cycles allowed): in debug builds every decide()
+//! call verifies the decide queue's bookkeeping invariants, so this property
+//! test checks the queue's wake-up machinery across arbitrary search shapes.
+
+use super::*;
+use proptest::prelude::*;
+
+type Dep = (usize, u32, u32);
+
+#[derive(Debug, Clone)]
+struct RandomProblem {
+    /// packages[i] = versions; each version body = (deps, constrains).
+    packages: Vec<Vec<(Vec<Dep>, Vec<Dep>)>>,
+    roots: Vec<Dep>,
+}
+
+fn spec(n_packages: usize) -> impl Strategy<Value = Dep> {
+    (0..n_packages, 0u32..5, 1u32..4)
+}
+
+fn random_problem() -> impl Strategy<Value = RandomProblem> {
+    (2usize..10).prop_flat_map(|n| {
+        let version_body = (
+            prop::collection::vec(spec(n), 0..=3),
+            prop::collection::vec(spec(n), 0..=1),
+        );
+        (
+            prop::collection::vec(prop::collection::vec(version_body, 1..=3), n),
+            prop::collection::vec(spec(n), 1..=3),
+        )
+            .prop_map(|(packages, roots)| RandomProblem { packages, roots })
+    })
+}
+
+fn to_spec_strings(deps: &[Dep]) -> Vec<String> {
+    deps.iter()
+        .map(|&(pkg, lo, len)| format!("p{pkg} {lo}..{}", lo + len))
+        .collect()
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+    #[test]
+    fn decide_queue_matches_reference_on_random_problems(problem in random_problem()) {
+        let n = problem.packages.len();
+        let mut provider = BundleBoxProvider::new();
+        for (pkg, versions) in problem.packages.iter().enumerate() {
+            for (version, (deps, constrains)) in versions.iter().enumerate() {
+                let deps = to_spec_strings(deps);
+                let deps: Vec<&str> = deps.iter().map(String::as_str).collect();
+                // A package constraining its own name trips a pre-existing
+                // debug assertion (Constrains(A, A) yields two identical
+                // watch literals); redirect those until that is fixed.
+                let constrains: Vec<Dep> = constrains
+                    .iter()
+                    .map(|&(target, lo, len)| {
+                        (if target == pkg { (target + 1) % n } else { target }, lo, len)
+                    })
+                    .collect();
+                let constrains = to_spec_strings(&constrains);
+                let constrains: Vec<&str> = constrains.iter().map(String::as_str).collect();
+                provider.add_package(
+                    &format!("p{pkg}"),
+                    (version as u32 + 1).into(),
+                    &deps,
+                    &constrains,
+                );
+            }
+        }
+
+        let roots = to_spec_strings(&problem.roots);
+        let roots: Vec<&str> = roots.iter().map(String::as_str).collect();
+        let requirements = provider.requirements(&roots);
+
+        let mut solver = Solver::new(provider);
+        let _ = solver.solve(Problem::new().requirements(requirements));
+    }
+}

--- a/tests/solver/main.rs
+++ b/tests/solver/main.rs
@@ -1490,3 +1490,110 @@ fn test_constrains_multiple_parents() {
     x=1
     "###);
 }
+
+// ============================================================================
+// Decide-queue wake-up scenarios
+// ============================================================================
+// Each test targets a wake-up path of `solver::decide_queue`. In debug builds
+// every decide() call verifies the queue's bookkeeping invariants, so these
+// tests check the queue throughout the search, not just the solution.
+
+/// Satisfied-watch break and re-satisfaction: a=2 satisfies its `x 2..3`
+/// requirement with x=2, the conflict with b's `x 1..2` undoes that, and
+/// after backtracking the requires clauses must become eligible again
+/// (parent re-wake) and be satisfiable by x=1. The conflict also bumps x,
+/// promoting queued items to the hot queue.
+#[test]
+fn test_decide_queue_satisfaction_break() {
+    let mut provider = BundleBoxProvider::new();
+    provider.add_package("x", 1.into(), &[], &[]);
+    provider.add_package("x", 2.into(), &[], &[]);
+    provider.add_package("a", 1.into(), &["x 1..2"], &[]);
+    provider.add_package("a", 2.into(), &["x 2..3"], &[]);
+    provider.add_package("b", 1.into(), &["x 1..2"], &[]);
+
+    let requirements = provider.requirements(&["a", "b"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    a=1
+    b=1
+    x=1
+    "###);
+}
+
+/// Backjump past a parent: mid=2 is undone by the conflict between its
+/// `leaf 2..3` requirement and root's explicit `leaf 1..2`, so mid's queued
+/// items become ineligible and mid=1's items must be woken afterwards.
+#[test]
+fn test_decide_queue_backjump_past_parent() {
+    let mut provider = BundleBoxProvider::new();
+    provider.add_package("leaf", 1.into(), &[], &[]);
+    provider.add_package("leaf", 2.into(), &[], &[]);
+    provider.add_package("mid", 1.into(), &["leaf 1..2"], &[]);
+    provider.add_package("mid", 2.into(), &["leaf 2..3"], &[]);
+    provider.add_package("top", 1.into(), &["mid"], &[]);
+
+    let requirements = provider.requirements(&["top", "leaf 1..2"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    leaf=1
+    mid=1
+    top=1
+    "###);
+}
+
+/// Condition wake-up in both polarities: the condition on `baz; if bar 2..3`
+/// completes and breaks as bar flips between 2 and 1 during the conflict
+/// with qux's `bar 1..2` requirement.
+#[test]
+fn test_decide_queue_condition_toggles() {
+    let mut provider = BundleBoxProvider::new();
+    provider.add_package("bar", 1.into(), &[], &[]);
+    provider.add_package("bar", 2.into(), &[], &[]);
+    provider.add_package("baz", 1.into(), &[], &[]);
+    provider.add_package("foo", 1.into(), &["baz; if bar 2..3"], &[]);
+    provider.add_package("qux", 1.into(), &["bar 1..2"], &[]);
+
+    let requirements = provider.requirements(&["foo", "bar", "qux"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    bar=1
+    foo=1
+    qux=1
+    "###);
+}
+
+/// Mid-solve reset: b=2's constraint on a is encoded only after a=1 is
+/// already installed, which reports a conflicting clause, resets the search
+/// to level 0 (clearing the decision tracker), and restarts. The queue's
+/// trail mirror must survive the reset.
+#[test]
+fn test_decide_queue_reset_on_late_conflict() {
+    let mut provider = BundleBoxProvider::new();
+    provider.add_package("a", 1.into(), &[], &[]);
+    provider.add_package("b", 1.into(), &[], &[]);
+    provider.add_package("b", 2.into(), &[], &["a 2..3"]);
+
+    let requirements = provider.requirements(&["a", "b"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    a=1
+    b=1
+    "###);
+}
+
+/// Union requirement naming the same package in several version sets: the
+/// queue's name occurrence lists deduplicate the item registration.
+#[test]
+fn test_decide_queue_union_duplicate_name() {
+    let mut provider = BundleBoxProvider::new();
+    provider.add_package("x", 1.into(), &[], &[]);
+    provider.add_package("x", 3.into(), &[], &[]);
+    provider.add_package("a", 1.into(), &["x 0..2 | x 3..4"], &[]);
+    provider.add_package("b", 1.into(), &["x 0..2"], &[]);
+
+    let requirements = provider.requirements(&["a", "b"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    a=1
+    b=1
+    x=1
+    "###);
+}
+
+mod decide_queue_prop;


### PR DESCRIPTION
This PR makes `Solver::decide` incremental. Instead of rescanning every requires clause of every installed parent on every call, the solver now maintains the set of clauses that are actually eligible for a decision and applies the existing heuristic to that set only.

The decision sequence is preserved **exactly**: on 2×1000 random conda-forge problems, statuses, solutions, unsat messages, and even the per-solve conflict and clause-visit counts are identical to main. Only the time changes.

**Background**

On main, `decide()` scans `requires_clauses` front to back on every call: it skips parents that are not assigned true, skips clauses with unsatisfied conditions, walks each remaining clause's sorted candidate list, and keeps a running best decision (explicit-first, higher activity, fewer candidates). The scan is repeated from scratch on every call, so on large problems it dominates the solver: ~10% of total solve time on the conda-forge dataset, and far more on conflict-heavy solves where decide() is called once per backtrack.

Only a small set of clauses is ever eligible, and eligibility only changes when specific variables change. This is the same observation that motivates [two watched literals](https://www.princeton.edu/~chaff/publication/DAC2001v56.pdf) in propagation, applied to the decision agenda. Modern SAT solvers ([MiniSat](https://github.com/niklasso/minisat/blob/master/minisat/core/Solver.h), [CaDiCaL](https://github.com/arminbiere/cadical), [Kissat](https://github.com/arminbiere/kissat)) never rescan either: they keep their decision candidates in an indexed heap or a [VMTF queue](https://cca.informatik.uni-freiburg.de/papers/BiereFroehlich-SAT15.pdf) and re-insert unassigned variables while unwinding the trail on backtrack (`insertVarOrder` in `cancelUntil`). [pubgrub-rs](https://github.com/pubgrub-rs/pubgrub/pull/274) does the equivalent for package resolution with an incrementally updated package priority queue.

**Implementation**

<img src="https://raw.githubusercontent.com/baszalmstra/resolvo/a0baf43ff49d0ed79acbe4894be2cdf895ee7cc5/architecture.svg" />

* Every requires clause is registered with the queue under its `ClausePosition`, a transparent newtype packing the parent's registration index and the clause's position in the parent's list (both append-only, so positions are stable and iterating by position visits clauses in a fixed, deterministic order).
* The queue itself is a `BTreeMap<ClausePosition, TrackedClauseId>`: position-ordered, mapping to the tracked requires clause. It holds a superset of the eligible clauses, restricted to parents currently assigned true. Clauses are only removed when an inspection in `next_decision` proves them ineligible, and every assignment change that could make an unqueued clause eligible re-inserts it through occurrence lists: by parent (wake on assigned-true), by candidate (a satisfied requirement keeps its satisfying candidate as a watch for O(1) skips), and by condition variable (wake on any change, since condition literals carry polarity).
* The occurrence lists need to know which variables changed since the previous `decide()`. The *trail* is the solver's chronological assignment log (the `DecisionTracker` stack): propagation pushes assignments onto it and backtracking pops them off, so it only ever changes at its end, and two snapshots of it always share a common prefix. The queue keeps a `mirror` of the trail from its previous call, and the tracker maintains a *sync floor*: the lowest trail length reached in between (one `usize::min` per undo; propagation pays nothing). Everything below the floor is that common prefix and is skipped. Mirror entries above the floor were popped at some point (possibly reassigned since), current trail entries above it were pushed; exactly those variables are re-routed through the occurrence lists. In the diagram below the trail grows from 6 to 9, backjumps to 3 and grows again to 8 between two calls: the floor is 3, so `mirror[3..6]` and `trail[3..8]` are processed and the first three entries are never touched. An assignment that was both made and undone in between falls in neither range; it has no net effect, and a consumer that only compares snapshots never needs to see it.

  <img src="https://raw.githubusercontent.com/baszalmstra/resolvo/a0baf43ff49d0ed79acbe4894be2cdf895ee7cc5/sync-floor.svg" />
* The candidate walk (first undecided candidate + undecided count) depends only on the requirement and the current assignment, so it is cached once per requirement and shared by all clauses with that requirement. Candidate occurrences are registered lazily on a requirement's first evaluation, because most encoded requirements belong to candidates that are never installed and are never evaluated.
* Selection takes the first eligible clause in position order as the initial best, then tries to replace it with eligible *hot* clauses after it. Replacement requires strictly higher activity (the package-level [VSIDS](https://github.com/prefix-dev/resolvo/pull/67) score) and strictly fewer remaining candidates; activities are non-negative, and a package never involved in a conflict has activity exactly 0, so only clauses naming a package whose activity was ever bumped can win. Hot clauses are mirrored in a second, much smaller `BTreeMap`. Selection stops early when the best has one candidate or activity equal to the tracked maximum (`max_activity` is maintained bit-exactly next to the bumps and the uniform decay).

  <img src="https://raw.githubusercontent.com/baszalmstra/resolvo/a0baf43ff49d0ed79acbe4894be2cdf895ee7cc5/selection.svg" />
* Since `with_activity_params` makes the activity parameters configurable, non-standard values (`add <= 0` or `decay < 0`) disable the hot-clause restriction and the activity early-stop; selection then visits every eligible clause, still in position order.

**Why the result is exactly the same**

The selection on main is a sequential pass over the eligible clauses in a fixed global order, keeping a running best. The queue preserves it by construction: iteration order is the clause position (it is the queue key), the queue always contains every eligible clause (the wake-up rules cover every removal site), the replacement rule is unchanged, and the clauses skipped by the hot-clause restriction can never win (activity 0 is never strictly higher).

During development the scan from main was additionally kept as a shadow implementation with a per-call equality assert; it stayed green over the full test suite (zero snapshot churn), over 273 corpus problems in an optimized-with-assertions build, and over the campaign. It is not kept in the final code: the selection heuristic lives in exactly one place (`next_decision`), so a heuristic change is a one-place edit. What is kept is a debug-build invariant check on every `decide()` for the heuristic-independent bookkeeping: every eligible clause is queued (recomputed from first principles), hot flags and the hot queue are in lockstep with the hot name set, and `max_activity` equals the largest stored activity. That machinery is the fragile part, and a hole in it does not crash or change solutions; the solver stays sound under any decision order and would just silently make worse decisions. Targeted scenario tests pin the wake-up paths (satisfaction break and re-satisfaction, backjump past a parent, condition toggling, mid-solve reset, union name dedup), and a property test solves random dependency graphs (cycles included) under those checks in CI.

**Benchmarks**

Conda-forge snapshot (`tools/solve-snapshot`), seeds 0 and 1, 1000 problems each, 60 s timeout, identical problem sequences on both sides, strictly sequential runs. Measured against current main (`61a0629`, which already includes the shared-constrains encoding of #236); the branch is rebased on it.

| metric | main | this PR |
|---|---:|---:|
| decide() time / 1000 solves (seed 0) | 121.9 s | **14.5 s (−88.1%)** |
| decide() time / 1000 solves (seed 1) | 101.1 s | **14.0 s (−86.2%)** |
| total solve time (seed 0) | 1223.7 s | **1119.1 s (−8.6%)** |
| total solve time (seed 1) | 1024.0 s | **908.2 s (−11.3%)** |
| p99 (seed 0 / 1) | 10.84 s / 5.99 s | **9.84 s (−9%) / 4.95 s (−17%)** |
| p50 (seed 0 / 1) | 0.569 s / 0.519 s | 0.567 s (−0.4%) / 0.498 s (−4.0%) |
| ok / unsat / timeout | 438/559/3 and 459/541/0 | 439/559/2 and 459/541/0 |

decide() drops from ~10% of total solver time to ~1.3%, so the end-to-end win concentrates where decide dominates: conflict-heavy and deep-backtracking solves. The single status difference is in the branch's favor: problem 171 of seed 0 times out on main and completes on the branch in 59.2 s. Every other outcome is identical, including the per-solve conflict and clause-visit counts on all 1997 solves completed by both sides (seed 1's total conflict count matches to the digit: 187,915). Per-solve outliers ≥50 ms and >1.5×: 14 faster vs 2 slower across both seeds; the worst regression over all 2000 problems is 0.19 s. An attempt to defer the clause-registration bookkeeping to the first conflict measured uniformly *slower* in an interleaved A/B, so registration stays eager.

<img src="https://raw.githubusercontent.com/baszalmstra/resolvo/a0baf43ff49d0ed79acbe4894be2cdf895ee7cc5/duration-histogram.png" />
<img src="https://raw.githubusercontent.com/baszalmstra/resolvo/a0baf43ff49d0ed79acbe4894be2cdf895ee7cc5/duration-diff-histogram.png" />

Top 5 most-improved problems (this PR vs main):

- `alchemiscale-server, botocore >=1.12.90,<1.13.0, blockdiag, ...` | **18.29s faster**
- `r-imgur, mp-api, r-ncdf4, xcb-util-wm-devel-conda-aarch64, ...` | **17.12s faster**
- `r-mopa, wbgapi, plothist, r-htmlutils, s3fs-fuse, ligo-proxy...` | **13.46s faster**
- `lua53, plant-seg, pygeoops, numba, cosmopharm, google-cloud-...` | **12.93s faster**
- `bcj-cffi, exchange-calendars, pyleiden, opentelemetry-instru...` | **10.99s faster**

Per-solve memory grows by an estimated 3-6% on the heaviest problems (one 40 B tracking entry per requires clause plus occurrence lists for evaluated requirements), which the diagnostics memory metric does not capture.




