### PR TITLE
ci: replace RELEASE_PLZ_TOKEN with octo-sts

### DIFF
--- a/.github/chainguard/write.sts.yaml
+++ b/.github/chainguard/write.sts.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/octo-sts/app/refs/heads/main/pkg/octosts/octosts.TrustPolicy.json
+issuer: https://token.actions.githubusercontent.com
+subject: repo:prefix-dev/resolvo:ref:refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,8 +1,7 @@
 name: Release-plz
 
 permissions:
-  pull-requests: write
-  contents: write
+  contents: read
 
 on:
   push:
@@ -13,16 +12,25 @@ jobs:
   release-plz:
     name: Release-plz
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
+      - name: Obtain GitHub app token
+        id: octo-sts
+        uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        with:
+          scope: ${{ github.repository }}
+          identity: write
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          token: ${{ steps.octo-sts.outputs.token }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@f9f65f52341ba3c1d5e1901c77dc7a9e58186191 # stable
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@064f4d1e36c843611ddf013be726beaa4ad804db # v0.5
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN  }}
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Switch release-plz workflow to use the octo-sts GitHub App for passwordless OIDC-based authentication instead of a static RELEASE_PLZ_TOKEN secret. Adds the chainguard trust policy granting write access to contents and pull requests from the main branch.