### PR TITLE
perf: watch the highest-decision-level literal in learned clauses

### DIFF
--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -1476,6 +1476,9 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
         let mut causes_at_current_level = 0u32;
         let mut learnt = Vec::new();
         let mut back_track_to = 0;
+        // Index in `learnt` of the highest-level non-asserting literal, moved
+        // to the front below so it becomes the second watch (watch2onhighest).
+        let mut highest_level_idx = 0;
 
         let mut s_value;
         let mut learnt_why = Vec::new();
@@ -1511,8 +1514,11 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
                                 .assigned_value(literal.variable())
                                 .unwrap(),
                         );
+                        if decision_level > back_track_to {
+                            back_track_to = decision_level;
+                            highest_level_idx = learnt.len();
+                        }
                         learnt.push(learnt_literal);
-                        back_track_to = back_track_to.max(decision_level);
                     } else {
                         unreachable!();
                     }
@@ -1542,6 +1548,13 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
             if causes_at_current_level == 0 {
                 break;
             }
+        }
+
+        // Watch the two highest-level literals: the asserting literal (pushed
+        // last) and the highest-level of the rest (moved to the front). They
+        // are unassigned last on backtracking, so the watches move least.
+        if !learnt.is_empty() {
+            learnt.swap(0, highest_level_idx);
         }
 
         let last_literal = Literal::new(conflicting_solvable, s_value);


### PR DESCRIPTION
This PR ports libsolv's [`watch2onhighest`](https://github.com/openSUSE/libsolv/blob/master/src/solver.c) heuristic to resolvo's conflict-clause learning. When `analyze` builds a learned clause, the asserting (1-UIP) literal is correctly watched as the clause's last literal, but the *second* watch was placed on whichever literal the analysis walk visited first, at an **arbitrary decision level**. Watching a low-level literal makes that watch turn false, and so require relocation, far more often during propagation and backtracking.

## Background

In a learned clause exactly one literal sits at the (former) current decision level, the asserting literal, and every other literal is at a strictly lower level. After learning, the solver backjumps to the second-highest level in the clause and the asserting literal propagates. From then on, the standard invariant every CDCL solver maintains ([MiniSat](http://minisat.se/downloads/MiniSat.pdf), [CaDiCaL](https://github.com/arminbiere/cadical)) is to keep the two watches on the clause's two highest-level literals: those are the last to be unassigned as the search backtracks, so the watch stays put across the most backjumps and the clause is re-examined the fewest times. resolvo watched the asserting literal (correct) and an arbitrary one (not), so the second watch frequently sat on a literal that a shallow backjump immediately invalidated, forcing the clause back through `propagate` to relocate it.

## Implementation

In `analyze` (`src/solver/mod.rs`): while collecting the non-asserting literals, record the index of the one with the highest decision level (reusing the `back_track_to` maximum that is already computed there) and `swap` it to the front before the asserting literal is pushed last. `WatchedLiterals::learnt` watches the first and last literals, so the two watches now land on the two highest-level literals. No new allocations, data structures, or extra passes; assertions (single-literal learnt clauses) are unaffected. Watch placement never affects soundness, only how often a watch moves, so the solver's results are unchanged except where a different propagation order leads the search down a different (occasionally better, occasionally worse) path.

## Benchmarks

Conda-forge `linux-64` + `noarch` snapshot (`tools/solve-snapshot`), seed 0, 1000 problems, 60 s timeout, release build, strictly sequential runs against main (`cc30c66`); the branch is rebased on it.

| metric | main | this PR |
|---|---:|---:|
| total solve time | 936.5 s | **846.0 s (-9.7%)** |
| mean | 0.937 s | **0.846 s (1.11x)** |
| p50 | 0.539 s | 0.491 s (1.10x) |
| p25 / p75 | 0.182 s / 1.249 s | 0.163 s / 1.147 s (1.12x / 1.09x) |
| timeouts (60 s) | 1 | 1 |

The win is broad rather than tail-only: of 915 non-trivial problems (>50 ms), **788 are faster, 50 slower, 77 unchanged**, and every percentile from p25 to p75 improves ~1.1x. Because watch placement perturbs propagation order it reorders exploration, so a minority of problems take a different path and a few resolve to a different but equally valid solution; per-decision version preference is unaffected.

<img width="1330" height="757" alt="image" src="https://github.com/user-attachments/assets/9abff285-8ba7-4395-af3d-75bd2295f8b8" />
<img width="1335" height="735" alt="image" src="https://github.com/user-attachments/assets/98b50569-d1e6-4b2e-97d7-b77f13b9de92" />


Top 5 most-improved problems (this PR vs main):

- `reposurgeon, metomi-rose, r-ravetools, nss-util-conda-aarch64, scriv, allennlp-optuna, ...` | **4.92 s faster**
- `patchy, spyql, nionswift-experimental, napari-meshio, ros-xmlrpcpp, binutils_linux-aarch64, ...` | **3.26 s faster**
- `opentelemetry-sdk ~=1.33.1, cirq-google, autoesda, cime_gen_domain, ansys-api-mapdl-v0, ...` | **3.15 s faster**
- `r-ps, grpc-cpp, setuptools-scm, dagster-cron, potentials, conda-merge, mo-dots, ...` | **2.87 s faster**
- `activity-browser` | **1.93 s faster**

The worst regression over all 1000 problems is +1.8 s (`roseau-load-flow, lmod, mill`); the next-worst is +0.79 s.

## Correctness

All 91 unit tests and the 20 `decide_queue` proptests pass. The change is heuristic-only: the per-clause literal set is identical, only the order of the first two entries differs, so watch invariants and unit-propagation results are preserved by construction.
