### PR TITLE
perf: share the requires disjunction across requirers with a gate variable per requirement

### DIFF
--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -118,6 +118,46 @@ impl Conflict {
             }
         }
 
+        // The shared requires encoding links a requirer to its candidate
+        // disjunction through a gate variable: a binary `AnyOf(gate, parent)`
+        // clause per requirer plus one `Requires(gate, ..)` disjunction. Collect
+        // the requirers per gate so the original `parent -> candidate` edges can
+        // be reconstructed when the gate's `Requires` clause is processed below.
+        let mut requires_gate_parents: HashMap<VariableId, Vec<SolvableIdOrRoot<D::SolvableId>>> =
+            HashMap::default();
+        for clause_id in &self.clauses {
+            if let Clause::AnyOf(selected, parent) = state.clauses.kinds[clause_id.to_index()] {
+                if matches!(
+                    state.variable_map.origin(selected),
+                    VariableOrigin::RequiresGate(_)
+                ) {
+                    if let Some(parent) = parent.as_solvable_or_root(&state.variable_map) {
+                        requires_gate_parents
+                            .entry(selected)
+                            .or_default()
+                            .push(parent);
+                    }
+                }
+            }
+        }
+        // If a gate is part of the conflict but its requirer's implication
+        // clause is not, recover the requirer from the gate's assignment reason.
+        for clause_id in &self.clauses {
+            if let Clause::Requires(gate, _, _) = state.clauses.kinds[clause_id.to_index()] {
+                if matches!(
+                    state.variable_map.origin(gate),
+                    VariableOrigin::RequiresGate(_)
+                ) && !requires_gate_parents.contains_key(&gate)
+                {
+                    if let Some(Clause::AnyOf(_, parent)) = reason_clause(gate) {
+                        if let Some(parent) = parent.as_solvable_or_root(&state.variable_map) {
+                            requires_gate_parents.insert(gate, vec![parent]);
+                        }
+                    }
+                }
+            }
+        }
+
         // Avoids adding the same edge once for each side of a chain.
         type ConstrainsEdge<S> = (SolvableIdOrRoot<S>, SolvableIdOrRoot<S>, VersionSetId);
         let mut constrains_edges: HashSet<ConstrainsEdge<D::SolvableId>> = HashSet::new();
@@ -145,34 +185,46 @@ impl Conflict {
                 }
                 Clause::Learnt(..) => unreachable!(),
                 &Clause::Requires(package_id, _condition, version_set_id) => {
-                    let solvable = package_id
-                        .as_solvable_or_root(&state.variable_map)
-                        .expect("only solvables can be excluded");
-                    let package_node = Self::add_node(&mut graph, &mut nodes, solvable);
+                    // The requiring solvable(s). With the shared requires
+                    // encoding the clause's parent is a gate variable; expand it
+                    // to the real requirers reconstructed above. A direct
+                    // requires clause has a single solvable/root parent.
+                    let parents: Vec<SolvableIdOrRoot<D::SolvableId>> =
+                        match package_id.as_solvable_or_root(&state.variable_map) {
+                            Some(solvable) => vec![solvable],
+                            None => requires_gate_parents
+                                .get(&package_id)
+                                .cloned()
+                                .unwrap_or_default(),
+                        };
 
                     let candidates = solver.async_runtime.block_on(solver.cache.get_or_cache_sorted_candidates(version_set_id)).unwrap_or_else(|_| {
                         unreachable!("The version set was used in the solver, so it must have been cached. Therefore cancellation is impossible here and we cannot get an `Err(...)`")
                     });
-                    if candidates.is_empty() {
-                        tracing::trace!(
-                            "{package_id:?} requires {version_set_id:?}, which has no candidates"
-                        );
-                        graph.add_edge(
-                            package_node,
-                            unresolved_node,
-                            ConflictEdge::Requires(version_set_id),
-                        );
-                    } else {
-                        for &candidate_id in candidates {
-                            tracing::trace!("{package_id:?} requires {candidate_id:?}");
 
-                            let candidate_node =
-                                Self::add_node(&mut graph, &mut nodes, candidate_id.into());
+                    for parent in parents {
+                        let package_node = Self::add_node(&mut graph, &mut nodes, parent);
+                        if candidates.is_empty() {
+                            tracing::trace!(
+                                "{parent:?} requires {version_set_id:?}, which has no candidates"
+                            );
                             graph.add_edge(
                                 package_node,
-                                candidate_node,
+                                unresolved_node,
                                 ConflictEdge::Requires(version_set_id),
                             );
+                        } else {
+                            for &candidate_id in candidates {
+                                tracing::trace!("{parent:?} requires {candidate_id:?}");
+
+                                let candidate_node =
+                                    Self::add_node(&mut graph, &mut nodes, candidate_id.into());
+                                graph.add_edge(
+                                    package_node,
+                                    candidate_node,
+                                    ConflictEdge::Requires(version_set_id),
+                                );
+                            }
                         }
                     }
                 }
@@ -283,10 +335,18 @@ impl Conflict {
                     }
                 }
                 Clause::AnyOf(selected, _variable) => {
-                    // Assumption: since `AnyOf` of clause can never be false, we dont add an edge
-                    // for it.
-                    let decision_map = solver.state.decision_tracker.map();
-                    debug_assert_ne!(selected.positive().eval(decision_map), Some(false));
+                    // No edge: at-least-one `AnyOf` clauses can never be false
+                    // (the selected variable is only ever propagated true), and
+                    // requires-gate implications are represented by the
+                    // `parent -> candidate` edges drawn from the gate's
+                    // `Requires` clause above.
+                    if !matches!(
+                        state.variable_map.origin(*selected),
+                        VariableOrigin::RequiresGate(_)
+                    ) {
+                        let decision_map = solver.state.decision_tracker.map();
+                        debug_assert_ne!(selected.positive().eval(decision_map), Some(false));
+                    }
                 }
             }
         }

--- a/src/solver/encoding.rs
+++ b/src/solver/encoding.rs
@@ -3,7 +3,7 @@ use std::{any::Any, collections::VecDeque};
 use super::{SolverState, clause::WatchedLiterals, conditions};
 use crate::{
     Candidates, ConditionId, ConditionalRequirement, DenseIndex, Dependencies, DependencyProvider,
-    SolverCache, StringId, VariableId, VersionSetId,
+    Requirement, SolverCache, StringId, VariableId, VersionSetId,
     internal::{id::ClauseId, solver_id::SolvableIdOrRoot},
     solver::{
         conditions::{DeferredConjunct, DeferredRequirement, Disjunction},
@@ -524,9 +524,11 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
             .insert(requirement.requirement, version_set_variables);
     }
 
-    /// Encodes an unconditional requirement `parent -> (c1 ∨ ... ∨ cN)` using a
-    /// shared gate variable, so the (often huge) candidate disjunction is
-    /// emitted once per requirement instead of once per requirer:
+    /// Encodes an unconditional requirement `parent -> (c1 ∨ ... ∨ cN)` through
+    /// a per-requirement gate variable (see
+    /// [`super::variable_map::VariableOrigin::RequiresGate`]), so the (often huge)
+    /// candidate disjunction is emitted once per requirement instead of once per
+    /// requirer:
     ///
     /// - once per requirement: the disjunction `(¬gate ∨ c1 ∨ ... ∨ cN)`;
     /// - once per requirer: the binary implication `(¬parent ∨ gate)`.
@@ -536,7 +538,7 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
     fn add_shared_requires(
         &mut self,
         parent: VariableId,
-        requirement: crate::Requirement,
+        requirement: Requirement,
         version_set_variables: &[Vec<VariableId>],
     ) {
         let gate = match self.state.requires_aux_vars.get(&requirement) {
@@ -548,9 +550,8 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
                     .alloc_requires_gate_variable(requirement);
                 self.state.requires_aux_vars.insert(requirement, gate);
 
-                // The shared disjunction, watched and registered with the decide
-                // queue exactly as a normal requires clause (its parent is the
-                // gate variable rather than a solvable).
+                // The shared disjunction, encoded as a normal requires clause
+                // whose parent is the gate.
                 let (watched_literals, conflict, kind) = WatchedLiterals::requires(
                     gate,
                     requirement,
@@ -566,11 +567,9 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
                 self.state
                     .add_requires_clause(gate, requirement, None, clause_id, names);
 
-                // `conflict` means every candidate is already false, so the
-                // disjunction reduces to `¬gate`. For a real requirer that is a
-                // conflict, but the gate is a fresh helper variable, so we just
-                // force it false; requirers then propagate to false through
-                // their implications.
+                // All candidates already false: the disjunction reduces to
+                // `¬gate`. The gate is a fresh helper, so just force it false
+                // (requirers then propagate false through their implications).
                 if conflict {
                     self.state
                         .decision_tracker
@@ -587,8 +586,15 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
         let (watched_literals, kind) = WatchedLiterals::any_of(gate, parent);
         let clause_id = self.state.add_clause(watched_literals, kind);
 
-        // Honor assignments already made for either end of the implication, the
-        // same way the other incremental encoders do.
+        // Track the requirer so a backtrack that strands the gate can be
+        // repaired (see [`SolverState::force_stuck_gates`]).
+        self.state
+            .requires_gate_requirers
+            .entry(gate)
+            .or_default()
+            .push((parent, clause_id));
+
+        // Honor assignments already made for either end of the implication.
         let forced = match (
             self.state.decision_tracker.assigned_value(parent),
             self.state.decision_tracker.assigned_value(gate),

--- a/src/solver/encoding.rs
+++ b/src/solver/encoding.rs
@@ -146,6 +146,12 @@ struct ConstraintCandidatesAvailable<'a, S> {
 /// clauses need at most as many clauses and propagate in a single hop.
 const CONSTRAINS_AUX_ENCODING_THRESHOLD: usize = 4;
 
+/// The minimum number of candidates an unconditional requirement must have
+/// before the shared gate encoding is used (see [`Encoder::add_shared_requires`]).
+/// Below this, re-emitting the small disjunction per requirer is cheaper than
+/// the gate variable, its disjunction clause and the extra propagation hop.
+const REQUIRES_AUX_ENCODING_THRESHOLD: usize = 4;
+
 impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
     pub fn new(
         state: &'a mut SolverState<D>,
@@ -458,9 +464,29 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
             conditions.push(None);
         }
 
+        let candidate_count: usize = version_set_variables.iter().map(Vec::len).sum();
+
         for condition in conditions {
             // Add the requirements clause
             let no_candidates = candidates.iter().all(|candidates| candidates.is_empty());
+
+            // Shared requires encoding: for an unconditional requirement of a
+            // non-root solvable with enough candidates, encode the candidate
+            // disjunction once on a shared gate variable and let this requirer
+            // imply the gate. Many solvables typically share the same
+            // requirement (version set), so this collapses a large number of
+            // duplicated giant disjunctions into one disjunction plus a binary
+            // implication per requirer. Root requirements stay direct so the
+            // decision heuristic can still recognise them as explicit.
+            if condition.is_none()
+                && !no_candidates
+                && !variable.is_root()
+                && candidate_count >= REQUIRES_AUX_ENCODING_THRESHOLD
+            {
+                self.add_shared_requires(variable, requirement.requirement, &version_set_variables);
+                continue;
+            }
+
             let condition_literals =
                 condition.map(|id| self.state.disjunctions[id].literals.as_slice());
             let (watched_literals, conflict, kind) = WatchedLiterals::requires(
@@ -496,6 +522,92 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
         self.state
             .requirement_to_sorted_candidates
             .insert(requirement.requirement, version_set_variables);
+    }
+
+    /// Encodes an unconditional requirement `parent -> (c1 ∨ ... ∨ cN)` using a
+    /// shared gate variable, so the (often huge) candidate disjunction is
+    /// emitted once per requirement instead of once per requirer:
+    ///
+    /// - once per requirement: the disjunction `(¬gate ∨ c1 ∨ ... ∨ cN)`;
+    /// - once per requirer: the binary implication `(¬parent ∨ gate)`.
+    ///
+    /// This mirrors the shared-constrains encoding (see
+    /// [`Encoder::on_constraint_candidates_available`]).
+    fn add_shared_requires(
+        &mut self,
+        parent: VariableId,
+        requirement: crate::Requirement,
+        version_set_variables: &[Vec<VariableId>],
+    ) {
+        let gate = match self.state.requires_aux_vars.get(&requirement) {
+            Some(&gate) => gate,
+            None => {
+                let gate = self
+                    .state
+                    .variable_map
+                    .alloc_requires_gate_variable(requirement);
+                self.state.requires_aux_vars.insert(requirement, gate);
+
+                // The shared disjunction, watched and registered with the decide
+                // queue exactly as a normal requires clause (its parent is the
+                // gate variable rather than a solvable).
+                let (watched_literals, conflict, kind) = WatchedLiterals::requires(
+                    gate,
+                    requirement,
+                    version_set_variables.iter().flatten().copied(),
+                    None,
+                    &self.state.decision_tracker,
+                );
+                let clause_id = self.state.add_clause(watched_literals, kind);
+
+                let names = requirement
+                    .version_sets(self.cache.provider())
+                    .map(|version_set| self.cache.provider().version_set_name(version_set));
+                self.state
+                    .add_requires_clause(gate, requirement, None, clause_id, names);
+
+                // `conflict` means every candidate is already false, so the
+                // disjunction reduces to `¬gate`. For a real requirer that is a
+                // conflict, but the gate is a fresh helper variable, so we just
+                // force it false; requirers then propagate to false through
+                // their implications.
+                if conflict {
+                    self.state
+                        .decision_tracker
+                        .try_add_decision(Decision::new(gate, false, clause_id), self.level)
+                        .expect("a freshly allocated gate variable cannot already be assigned");
+                }
+
+                gate
+            }
+        };
+
+        // The implication `parent -> gate`, encoded as the binary clause
+        // `(gate ∨ ¬parent)` (the `AnyOf` shape).
+        let (watched_literals, kind) = WatchedLiterals::any_of(gate, parent);
+        let clause_id = self.state.add_clause(watched_literals, kind);
+
+        // Honor assignments already made for either end of the implication, the
+        // same way the other incremental encoders do.
+        let forced = match (
+            self.state.decision_tracker.assigned_value(parent),
+            self.state.decision_tracker.assigned_value(gate),
+        ) {
+            (Some(true), Some(false)) => {
+                // The requirer is installed but the gate is already false.
+                self.conflicting_clauses.push(clause_id);
+                return;
+            }
+            (Some(true), None) => Some(Decision::new(gate, true, clause_id)),
+            (None, Some(false)) => Some(Decision::new(parent, false, clause_id)),
+            _ => None,
+        };
+        if let Some(decision) = forced {
+            self.state
+                .decision_tracker
+                .try_add_decision(decision, self.level)
+                .expect("we checked that the variable is not yet assigned");
+        }
     }
 
     /// Called when the candidates for a particular constraint are available.

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -228,6 +228,13 @@ pub(crate) struct SolverState<D: DependencyProvider> {
     /// once, when the variable is allocated.
     constrains_aux_vars: HashMap<VersionSetId, VariableId>,
 
+    /// The gate variable of the shared requires encoding per requirement. The
+    /// single candidate disjunction (`Clause::Requires` on the gate) is emitted
+    /// exactly once, when the variable is allocated; each requirer then only
+    /// adds a binary implication to the gate. See
+    /// [`variable_map::VariableOrigin::RequiresGate`].
+    requires_aux_vars: HashMap<Requirement, VariableId>,
+
     pub(crate) decision_tracker: DecisionTracker,
 
     /// Activity score per package.
@@ -277,6 +284,7 @@ impl<D: DependencyProvider> Default for SolverState<D> {
             at_most_one_trackers: Default::default(),
             at_least_one_tracker: Default::default(),
             constrains_aux_vars: Default::default(),
+            requires_aux_vars: Default::default(),
             decision_tracker: Default::default(),
             name_activity: Default::default(),
             max_activity: 0.0,

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -235,6 +235,15 @@ pub(crate) struct SolverState<D: DependencyProvider> {
     /// [`variable_map::VariableOrigin::RequiresGate`].
     requires_aux_vars: HashMap<Requirement, VariableId>,
 
+    /// For each shared-requires gate, the requirers that imply it
+    /// (`(¬requirer ∨ gate)`) and the implication clause. The encoder forces the
+    /// gate true at its own (lazy, often higher) level, so a backtrack can
+    /// strand it (the implication is unit but watched literals never re-fire on
+    /// an unassignment); [`SolverState::force_stuck_gates`] uses this to
+    /// re-derive such gates. An [`IndexMap`] so the forcing order, and hence the
+    /// solution, stays deterministic.
+    requires_gate_requirers: IndexMap<VariableId, Vec<(VariableId, ClauseId)>, ahash::RandomState>,
+
     pub(crate) decision_tracker: DecisionTracker,
 
     /// Activity score per package.
@@ -285,6 +294,7 @@ impl<D: DependencyProvider> Default for SolverState<D> {
             at_least_one_tracker: Default::default(),
             constrains_aux_vars: Default::default(),
             requires_aux_vars: Default::default(),
+            requires_gate_requirers: Default::default(),
             decision_tracker: Default::default(),
             name_activity: Default::default(),
             max_activity: 0.0,
@@ -714,7 +724,17 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
             // conclude the solution is complete.
             let fired_conditions = self.state.fired_deferred_conditions();
 
+            // Re-derive shared-requires gates stranded by a backtrack, else the
+            // gated requirement would be silently dropped (see
+            // [`SolverState::force_stuck_gates`]).
+            let forced_stuck_gates = self.state.force_stuck_gates(level);
+
             if new_solvables.is_empty() && fired_conditions.is_empty() {
+                if forced_stuck_gates {
+                    // Only gates were repaired: loop to propagate and re-decide.
+                    continue;
+                }
+
                 // If no new literals were selected and no deferred conditions
                 // fired, this solution is complete and we can return.
                 tracing::trace!(
@@ -1684,6 +1704,37 @@ impl<D: DependencyProvider> SolverState<D> {
             Some(variable) => self.decision_tracker.assigned_value(variable) == Some(true),
             None => false,
         }
+    }
+
+    /// Forces true every stranded shared-requires gate (unassigned, but with an
+    /// installed requirer that implies it), using the requirer's implication
+    /// clause as the reason so conflict analysis stays correct. Returns whether
+    /// any were forced. Assigned gates are left alone (a false gate with an
+    /// installed requirer is a real conflict propagation already reports).
+    /// Forcing a gate never changes a requirer, so one in-place pass suffices.
+    pub(crate) fn force_stuck_gates(&mut self, level: u32) -> bool {
+        let Self {
+            requires_gate_requirers,
+            decision_tracker,
+            ..
+        } = self;
+
+        let mut forced_any = false;
+        for (&gate, requirers) in requires_gate_requirers.iter() {
+            if decision_tracker.assigned_value(gate).is_some() {
+                continue;
+            }
+            if let Some(&(_, reason)) = requirers
+                .iter()
+                .find(|&&(requirer, _)| decision_tracker.assigned_value(requirer) == Some(true))
+            {
+                decision_tracker
+                    .try_add_decision(Decision::new(gate, true, reason), level)
+                    .expect("a stuck gate is unassigned, so the decision cannot conflict");
+                forced_any = true;
+            }
+        }
+        forced_any
     }
 
     /// Returns the `ConditionId`s of deferred requirements whose gating

--- a/src/solver/variable_map.rs
+++ b/src/solver/variable_map.rs
@@ -44,11 +44,14 @@ pub(crate) enum VariableOrigin<N, S> {
     /// version set is installed.
     ConstrainsViolation(VersionSetId),
 
-    /// A variable that gates the shared "at least one candidate" disjunction
-    /// for a requirement. Many solvables can require the same version set; each
-    /// requirer implies this gate, and the gate implies the (single, shared)
-    /// candidate disjunction, so the disjunction is encoded once instead of
-    /// once per requirer.
+    /// The output variable of the OR-gate formed by a requirement's candidate
+    /// disjunction `c1 | ... | cN`, in the Tseitin circuit-to-CNF sense.
+    /// Requirers imply the gate (`requirer -> gate`) and the gate implies the
+    /// disjunction (`gate -> c1 | ... | cN`), so the (often large) disjunction is
+    /// defined once and shared by every requirer instead of being repeated for
+    /// each. Only the `gate -> disjunction` direction is encoded (the gate is
+    /// never forced true except by a requirer): the one-sided Plaisted-Greenbaum
+    /// encoding, mirroring the constrains side at the opposite polarity.
     RequiresGate(Requirement),
 }
 

--- a/src/solver/variable_map.rs
+++ b/src/solver/variable_map.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use crate::{
-    DenseIndex, Interner, VariableId, VersionSetId,
+    DenseIndex, Interner, Requirement, VariableId, VersionSetId,
     internal::solver_id::SolvableIdOrRoot,
     solver_id::{IdMap, SolverId},
 };
@@ -43,6 +43,13 @@ pub(crate) enum VariableOrigin<N, S> {
     /// A variable that indicates that a candidate excluded by a constraint's
     /// version set is installed.
     ConstrainsViolation(VersionSetId),
+
+    /// A variable that gates the shared "at least one candidate" disjunction
+    /// for a requirement. Many solvables can require the same version set; each
+    /// requirer implies this gate, and the gate implies the (single, shared)
+    /// candidate disjunction, so the disjunction is encoded once instead of
+    /// once per requirer.
+    RequiresGate(Requirement),
 }
 
 impl<N: SolverId, S: SolverId> Default for VariableMap<N, S> {
@@ -127,6 +134,12 @@ impl<N: SolverId, S: SolverId> VariableMap<N, S> {
         self.alloc(VariableOrigin::ConstrainsViolation(version_set))
     }
 
+    /// Allocate a variable that gates the shared candidate disjunction of a
+    /// requirement (see [`VariableOrigin::RequiresGate`]).
+    pub fn alloc_requires_gate_variable(&mut self, requirement: Requirement) -> VariableId {
+        self.alloc(VariableOrigin::RequiresGate(requirement))
+    }
+
     /// Returns the origin of a variable. The origin describes the semantics of
     /// a variable.
     #[inline]
@@ -194,6 +207,9 @@ impl<I: Interner> Display for VariableDisplay<'_, I> {
                         .display_name(self.interner.version_set_name(version_set)),
                     self.interner.display_version_set(version_set)
                 )
+            }
+            VariableOrigin::RequiresGate(requirement) => {
+                write!(f, "requires-gate({})", requirement.display(self.interner))
             }
         }
     }

--- a/tests/solver/bundle_box/mod.rs
+++ b/tests/solver/bundle_box/mod.rs
@@ -25,13 +25,41 @@ use std::{
     cell::{Cell, RefCell},
     collections::HashSet,
     fmt::Display,
+    future::Future,
+    pin::Pin,
     rc::Rc,
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     },
+    task::{Context, Poll},
     time::Duration,
 };
+
+/// A future that is `Pending` for exactly `remaining` polls (waking itself each
+/// time) and then `Ready`. The encoder drives the provider's futures with a
+/// `FuturesUnordered` on a current-thread runtime, whose poll order is
+/// deterministic, so the number of pending polls controls the order in which
+/// calls resolve as a pure function of the input, with no dependence on
+/// wall-clock time (unlike `tokio::time::sleep`).
+struct PendingPolls {
+    remaining: u32,
+}
+
+impl Future for PendingPolls {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.remaining == 0 {
+            Poll::Ready(())
+        } else {
+            self.remaining -= 1;
+            // Re-schedule ourselves so the executor polls us again.
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
+}
 
 use ahash::HashMap;
 pub use conditional_spec::{ConditionalSpec, SpecCondition};
@@ -61,6 +89,12 @@ pub struct BundleBoxProvider {
     concurrent_requests: Arc<AtomicUsize>,
     pub concurrent_requests_max: Rc<Cell<usize>>,
     pub sleep_before_return: bool,
+    /// When non-zero, `maybe_delay` varies the number of pending polls per call
+    /// using a seeded hash, exploring different (but fully deterministic) async
+    /// encoding orders. Different seeds give different orders; a given seed
+    /// always reproduces the same one.
+    pub delay_seed: u64,
+    delay_counter: Cell<u64>,
     /// When set, candidates are returned with
     /// [`HintDependenciesAvailable::All`], which makes the solver prefetch
     /// (and encode) the dependencies of requirement candidates as soon as the
@@ -210,8 +244,28 @@ impl BundleBoxProvider {
     // runtime available)
     async fn maybe_delay<T: Send + 'static>(&self, value: T) -> T {
         if self.sleep_before_return {
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            if self.delay_seed == 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                self.concurrent_requests.fetch_sub(1, Ordering::SeqCst);
+                return value;
+            }
+            let n = self.delay_counter.get();
+            self.delay_counter.set(n + 1);
+            let mut h = self.delay_seed ^ n.wrapping_mul(0x9E3779B97F4A7C15);
+            h ^= h >> 30;
+            h = h.wrapping_mul(0xBF58476D1CE4E5B9);
+            h ^= h >> 27;
             self.concurrent_requests.fetch_sub(1, Ordering::SeqCst);
+            // Mimic prefetch cache hits: ~1/3 of calls resolve synchronously
+            // (no pending poll -> no yield), the rest stay pending for a seeded
+            // number of polls. The mix of sync and async returns is what a
+            // prefetching provider produces, and the poll count gives a
+            // deterministic, wall-clock-independent resolution order.
+            let polls = match h % 3 {
+                0 => 0, // synchronous (cache hit)
+                _ => 1 + (h >> 2) as u32 % 20,
+            };
+            PendingPolls { remaining: polls }.await;
             value
         } else {
             value

--- a/tests/solver/main.rs
+++ b/tests/solver/main.rs
@@ -2216,3 +2216,166 @@ fn test_decide_queue_union_duplicate_name() {
 }
 
 mod decide_queue_prop;
+
+/// A generated dependency graph: `(name, version, deps)` triples plus root specs.
+type GateFuzzGraph = (Vec<(String, u32, Vec<String>)>, Vec<String>);
+
+/// A tiny xorshift RNG used to generate the shared-requires gate fuzz graphs.
+struct GateFuzzRng(u64);
+
+impl GateFuzzRng {
+    fn new(seed: u64) -> Self {
+        Self(seed.wrapping_mul(0x9E3779B97F4A7C15) | 1)
+    }
+
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+}
+
+/// Generates a random dependency graph as `(name, version, deps)` triples plus a
+/// set of root requirements. Multi-version packages produce requirements with
+/// enough candidates to be encoded behind a shared gate, the structure that
+/// triggered the stranded-gate bug.
+fn gen_gate_fuzz_graph(seed: u64) -> GateFuzzGraph {
+    let mut r = GateFuzzRng::new(seed);
+    let n = 5 + (r.next() % 6) as usize;
+    let names: Vec<String> = (0..n).map(|i| format!("p{i}")).collect();
+    let mut pkgs = Vec::new();
+    for (i, name) in names.iter().enumerate() {
+        let versions = 1 + (r.next() % 5) as u32;
+        for v in 1..=versions {
+            let num_deps = (r.next() % 4) as usize;
+            let mut deps = Vec::new();
+            for _ in 0..num_deps {
+                let j = (r.next() as usize) % n;
+                if j == i {
+                    continue;
+                }
+                if r.next() % 3 == 0 {
+                    let lo = 1 + (r.next() % 3) as u32;
+                    let hi = lo + 1 + (r.next() % 3) as u32;
+                    deps.push(format!("{} {}..{}", names[j], lo, hi));
+                } else {
+                    deps.push(names[j].clone());
+                }
+            }
+            pkgs.push((name.clone(), v, deps));
+        }
+    }
+    let num_roots = 1 + (r.next() % 3) as usize;
+    let roots = (0..num_roots)
+        .map(|_| names[(r.next() as usize) % n].clone())
+        .collect();
+    (pkgs, roots)
+}
+
+/// Checks that `sol` is a *complete* solution of `(pkgs, roots)`: every root and
+/// every dependency of an installed package is satisfied by an installed
+/// package.
+fn validate_complete(
+    pkgs: &[(String, u32, Vec<String>)],
+    roots: &[String],
+    sol: &[(String, u32)],
+) -> Result<(), String> {
+    use std::collections::HashMap;
+    let chosen: HashMap<&str, u32> = sol.iter().map(|(n, v)| (n.as_str(), *v)).collect();
+    let satisfied = |spec: &str| -> bool {
+        let mut it = spec.split_whitespace();
+        let name = it.next().unwrap();
+        let Some(&cv) = chosen.get(name) else {
+            return false;
+        };
+        match it.next() {
+            None => true,
+            Some(range) => {
+                let mut p = range.split("..");
+                let lo: u32 = p.next().unwrap().parse().unwrap();
+                let hi: u32 = p.next().unwrap().parse().unwrap();
+                cv >= lo && cv < hi
+            }
+        }
+    };
+    for root in roots {
+        if !satisfied(root) {
+            return Err(format!("root `{root}` is unsatisfied"));
+        }
+    }
+    for (name, version) in sol {
+        let deps = &pkgs
+            .iter()
+            .find(|(n, v, _)| n == name && v == version)
+            .unwrap()
+            .2;
+        for dep in deps {
+            if !satisfied(dep) {
+                return Err(format!(
+                    "{name}=={version} requires `{dep}` which is absent"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Solves `(pkgs, roots)` through the async `BundleBoxProvider` with `delay_seed`
+/// (which varies the encode/backtrack interleaving). Returns the installed
+/// `(name, version)` set, or `None` if the problem is reported unsatisfiable.
+fn solve_gate_fuzz(
+    pkgs: &[(String, u32, Vec<String>)],
+    roots: &[String],
+    delay_seed: u64,
+) -> Option<Vec<(String, u32)>> {
+    let pp: Vec<(&str, u32, Vec<&str>)> = pkgs
+        .iter()
+        .map(|(n, v, d)| (n.as_str(), *v, d.iter().map(String::as_str).collect()))
+        .collect();
+    let mut provider = BundleBoxProvider::from_packages(&pp);
+    provider.sleep_before_return = true;
+    provider.delay_seed = delay_seed;
+    let root_specs: Vec<&str> = roots.iter().map(String::as_str).collect();
+    let reqs = provider.requirements(&root_specs);
+    // A seeded `delay_seed` drives ordering through cooperative polling, not
+    // timers, so the runtime needs no time support.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+    let mut solver = Solver::new(provider).with_runtime(rt);
+    let solution = solver.solve(Problem::new().requirements(reqs)).ok()?;
+    Some(
+        solution
+            .iter()
+            .map(|s| {
+                let display = format!("{}", solver.provider().display_solvable(*s));
+                let mut it = display.split('=');
+                (
+                    it.next().unwrap().to_string(),
+                    it.next_back().unwrap().parse().unwrap(),
+                )
+            })
+            .collect(),
+    )
+}
+
+/// Regression for the shared-requires gate (PR #246): an async-ordering
+/// backtrack could strand the gate (unassign it while a requirer stayed
+/// installed), silently dropping the gated requirement. This fuzzer-derived
+/// graph (`p3==3` requires the gated `p7`) reproduces it across delay seeds;
+/// every returned solution must be complete.
+#[test]
+fn shared_requires_gate_survives_backtrack() {
+    let (pkgs, roots) = gen_gate_fuzz_graph(542);
+    for delay_seed in 1..=12u64 {
+        if let Some(sol) = solve_gate_fuzz(&pkgs, &roots, 542_000 + delay_seed) {
+            validate_complete(&pkgs, &roots, &sol).unwrap_or_else(|e| {
+                panic!(
+                    "delay seed {} produced an incomplete solution: {e}",
+                    542_000 + delay_seed
+                )
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This pull request replaces the per-requirer `Requires` clause encoding with a shared gate-variable encoding. Previously every "P requires V" relationship emitted the full candidate disjunction `(not P or c1 or ... or cN)`, so the same candidate list was re-emitted for every solvable that shared the requirement. On conda-forge style workloads many packages require the same version set of a popular dependency, so these duplicated disjunctions dominate the clause database and propagation.

This is the requires-side counterpart of the shared-constrains encoding from #236.

## Key Changes

Unconditional requirements with at least 4 candidates now share one gate variable per requirement, meaning "some candidate of this requirement is installed":

- the disjunction `(not gate or c1 or ... or cN)`, emitted once per requirement;
- the binary implication `(not P or gate)`, one clause per requirer (the existing `AnyOf` shape).

This reduces the requires encoding from O(requirers x candidates) to O(requirers + candidates). Requirements with fewer than 4 candidates keep the direct encoding, which is smaller for short lists. Root requirements also stay direct, so the decision heuristic still recognises them as explicit (criterion 1, "prefer direct dependencies").

On the worst single problem in the benchmark (`mp_pytorch`), the encoded requires clauses carry 64.5M candidate literals across 896k clauses over only 29k distinct requirements; the shared encoding collapses 766k duplicate disjunctions and brings the candidate literal count down to 2.5M, about 25x fewer.

## Performance Results

Benchmarked on the conda-forge dataset (linux-64 + noarch snapshot, 127k solvables, 1000 randomized problems, seed 0, identical problem sequences on both sides, clean release builds, 30s timeout). Measured against current `main` (`3644218`), which already includes the learned-clause watch optimization of #245; the branch is rebased on it.

| metric | main | this PR | speedup |
|--------|-----:|--------:|--------:|
| total solve time | 923.0s | 596.2s | **1.55x** (35% less) |
| mean | 0.92s | 0.60s | 1.55x |
| median (p50) | 0.50s | 0.41s | 1.20x |
| p95 | 2.07s | 1.49s | 1.39x |
| p99 | 7.31s | 1.82s | **4.03x** |
| max | 30.0s | 3.21s | 9.4x |
| timeouts | 2 | 0 | |

97.9% of problems are faster, 2.1% slower. The gains extend the solvable frontier: main hits the 30s timeout on 2 problems, this PR on 0, and the largest single improvement is a 30s timeout that now resolves in 0.35s. The worst regression over the 1000 problems is +0.8s, both sides completing.

The per-problem difference histogram uses a log y-axis: 947 of 1000 problems sit in the near-zero bin, so the improvement tail (the multi-second wins) is only visible on a log scale.

<img width="900" src="https://raw.githubusercontent.com/baszalmstra/resolvo/6aba0fb233d74696110c3d06e21f8e7c040ab14c/cf-duration-histogram.png" />

<img width="900" src="https://raw.githubusercontent.com/baszalmstra/resolvo/6aba0fb233d74696110c3d06e21f8e7c040ab14c/cf-duration-diff-histogram.png" />

The win grows with problem difficulty: aggregated by how long a problem takes on main, the solve-time reduction is small for sub-second problems and grows to multiple x for the heavy tail. Easy solves stay flat, the tail compresses.

### Wider corpus: conda-forge + conda-pypi

To check the result beyond a single channel, the same benchmark was run on a snapshot mixing conda-forge with conda-pypi (the sharded PyPI-mapped channel, fetched through the gateway). The recursive closure of a broad seed set produces 261k records spanning both channels, and the PyPI-mapped packages with their extras (for example `zipp[testing]`, `keyring[type]`, `mypy-boto3[ebs]`) are exercised directly.

| metric | main | this PR | speedup |
|--------|-----:|--------:|--------:|
| total solve time | 247.2s | 195.4s | 1.27x (21% less) |
| max | 30.0s | 2.11s | |
| timeouts | 1 | 0 | |
| problems faster | | 83.6% | |

<img width="900" src="https://raw.githubusercontent.com/baszalmstra/resolvo/6aba0fb233d74696110c3d06e21f8e7c040ab14c/wide-duration-diff-histogram.png" />

## Technical Rationale

Propagation strength is preserved in two hops instead of one. The gate is a one-sided (polarity-aware) [Plaisted-Greenbaum](https://doi.org/10.1016/S0747-7171(86)80028-1) variable: `P = true` propagates `gate = true`, and once every candidate of the requirement is false the disjunction propagates `gate = false`, which conflicts back through `(not P or gate)`. Only one implication polarity is needed because the gate is never decided directly, it only takes a value through propagation. This is exactly the mechanism #236 introduced for constraints, applied to the opposite polarity for requirements.

Conflict reporting reconstructs the original `parent to candidate` edges by pairing the gate's disjunction clause with the per-requirer `AnyOf` implications through the shared gate variable, so rendered conflict messages are identical to the direct encoding on the entire existing test suite.

## Correctness

- The full test suite passes with byte-identical snapshots; the conflict-graph reconstruction means diagnostics are unchanged.
- Every explicitly requested package resolves and there are no ok/unsat flips. On the conda-forge run, 980 of 1000 solutions are identical and the remaining 20 differ only in transitive picks, both sides valid and verified complete. On the wider corpus only 1 of 1000 differs.

I went through all 20 differing conda-forge solutions in detail to characterise what actually changes:

| metric | result |
|--------|-------:|
| requested packages dropped | 0 / 20 |
| requested packages with a version change | 1 / 20 |

The single requested-package change is an upgrade (`ibis-clickhouse` 8.0.0 to 9.5.0); no direct dependency is ever dropped or downgraded. Everything else is transitive movement:

```
transitive version changes:  newer 52 | older 198 | build-string-only 86
packages added: 76   removed: 112
```

The "older" total looks large but is almost entirely a single problem: case 274 alone accounts for 147 of the 198 older picks. There the branch resolves a newer `ibis-clickhouse` (9.5.0) and `ibis-framework-core` (9.5.0) into a smaller environment (470 vs 494 packages), at the cost of an older surrounding stack (`dask-core` 2023.3.0 vs 2026.6.0, `click` 7.1.2 vs 8.1.3). Excluding that one problem the remaining spread is 31 newer / 51 older, mild and mixed.

This is the documented decision heuristic at work rather than a regression. resolvo prefers explicit requirements over transitive ones (criterion 1, "direct dependencies are maximized over transitive dependencies") and does greedy heuristic search rather than branch-and-bound for a globally newest solution, so it returns a valid local optimum whose transitive picks are search dependent. Shifting the encoding shifts that search path among equally valid choices; the existing activity heuristic already makes transitive picks search dependent in the same way. In case 274 the branch's solution is if anything more aligned with criterion 1, since it maximised the direct requirement and took the older transitive deps as the cost.

Concrete examples of the variation:

- `terraform-provider-powerdns` (320 to 319): an older but valid grid stack (`gsoap` 2.8.117 vs 2.8.123, `davix` 0.8.0 vs 0.8.3), dropping one package.
- `rubinenv` (383 to 391): resolves the `imagecodecs` requirement to the full `imagecodecs` package and its 8 deps instead of `imagecodecs-lite`.
- `tigernet` (549 to 530): older `sardana` / `taurus` that avoid pulling a `graphviz` / `gtk2` / `librsvg` stack, 19 fewer packages.

This is the same class of transitive-pick variation #236 documented and accepted (#236 reported 1.6%, this is about 2.0%). No requested or direct dependency is dropped or pushed out of its allowed range.
