### PR TITLE
fix: report the exclusion reason for an excluded locked solvable

### DIFF
--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -862,6 +862,21 @@ impl<'i, I: Interner> DisplayUnsat<'i, I> {
         }
     }
 
+    /// Returns the reason a solvable was excluded, if it was.
+    fn excluded_reason(&self, solvable_id: I::SolvableId) -> Option<StringId> {
+        let graph = &self.graph.graph;
+        let node = graph
+            .node_indices()
+            .find(|&node| graph[node] == ConflictNode::Solvable(solvable_id))?;
+        graph.edges(node).find_map(|e| match e.weight() {
+            ConflictEdge::Conflict(ConflictCause::Excluded) => match graph[e.target()] {
+                ConflictNode::Excluded(reason) => Some(reason),
+                _ => unreachable!("an excluded edge must point to an excluded node"),
+            },
+            _ => None,
+        })
+    }
+
     fn fmt_graph(
         &self,
         f: &mut Formatter<'_>,
@@ -1188,16 +1203,12 @@ impl<I: Interner> fmt::Display for DisplayUnsat<'_, I> {
             writeln!(f, "The following packages are incompatible")?;
             self.fmt_graph(f, &top_level_conflicts, true)?;
 
-            // Conflicts caused by locked dependencies
-            let mut edges = self.graph.graph.edges(self.graph.root_node).peekable();
-            let indenter = Indenter::new(true);
-            while let Some(e) = edges.next() {
-                let indenter = indenter.push_level_with_order(match edges.peek() {
-                    Some(_) => ChildOrder::HasRemainingSiblings,
-                    None => ChildOrder::Last,
-                });
-                let indent = indenter.get_indent();
-
+            // Conflicts caused by locked dependencies. Every `Lock` clause
+            // produces its own root edge, one per forbidden candidate, so the
+            // lines are deduplicated by the solvable that is locked.
+            let mut reported_locked = HashSet::new();
+            let mut lines = Vec::new();
+            for e in self.graph.graph.edges(self.graph.root_node) {
                 let conflict = match e.weight() {
                     ConflictEdge::Requires(_) => continue,
                     ConflictEdge::Conflict(conflict) => conflict,
@@ -1206,27 +1217,49 @@ impl<I: Interner> fmt::Display for DisplayUnsat<'_, I> {
                 // The only possible conflict at the root level is a Locked conflict
                 match conflict {
                     &ConflictCause::Constrains(version_set_id) => {
-                        writeln!(
-                            f,
-                            "{indent}the constraint {name} {version_set} cannot be fulfilled",
+                        lines.push(format!(
+                            "the constraint {name} {version_set} cannot be fulfilled",
                             name = self
                                 .interner
                                 .display_name(self.interner.version_set_name(version_set_id)),
                             version_set = self.interner.display_version_set(version_set_id),
-                        )?;
+                        ));
                     }
                     &ConflictCause::ForbidMultipleInstances => {
                         unreachable!()
                     }
                     &ConflictCause::Locked(solvable_id) => {
-                        writeln!(
-                            f,
-                            "{indent}{} is locked, but another version is required as reported above",
-                            self.interner.display_merged_solvables(&[solvable_id]),
-                        )?;
+                        if !reported_locked.insert(solvable_id) {
+                            continue;
+                        }
+                        // A locked solvable that is itself excluded rules the
+                        // package out entirely; the reason is part of the
+                        // conflict, so report it instead of implying that the
+                        // locked version would work.
+                        match self.excluded_reason(solvable_id) {
+                            Some(reason) => lines.push(format!(
+                                "{} is locked, but it is excluded because {}",
+                                self.interner.display_merged_solvables(&[solvable_id]),
+                                self.interner.display_string(reason),
+                            )),
+                            None => lines.push(format!(
+                                "{} is locked, but another version is required as reported above",
+                                self.interner.display_merged_solvables(&[solvable_id]),
+                            )),
+                        }
                     }
                     ConflictCause::Excluded => continue,
                 };
+            }
+
+            let indenter = Indenter::new(true);
+            let mut lines = lines.into_iter().peekable();
+            while let Some(line) = lines.next() {
+                let indenter = indenter.push_level_with_order(match lines.peek() {
+                    Some(_) => ChildOrder::HasRemainingSiblings,
+                    None => ChildOrder::Last,
+                });
+                writeln!(f, "{}{line}", indenter.get_indent())?;
             }
         }
 

--- a/tests/solver/main.rs
+++ b/tests/solver/main.rs
@@ -434,6 +434,28 @@ fn test_unsat_locked_and_excluded() {
     insta::assert_snapshot!(solve_snapshot(provider, &["asdf"]));
 }
 
+/// A locked solvable that is itself excluded rules out the whole package:
+/// the lock forbids every other candidate and the exclusion the locked one.
+/// The conflict must surface the exclusion reason, otherwise the report
+/// claims the locked version is required while hiding why it cannot be used.
+#[test]
+fn test_unsat_locked_solvable_is_excluded() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("c", 1, vec![]),
+        ("c", 2, vec![]),
+        ("c", 3, vec![]),
+        ("c", 4, vec![]),
+    ]);
+    provider.set_locked("c", 1);
+    provider.exclude("c", 1, "it is not available locally");
+    insta::assert_snapshot!(solve_snapshot(provider, &["c"]), @r"
+    The following packages are incompatible
+    └─ c * can be installed with any of the following options:
+       └─ c 2 | 3 | 4
+    └─ c 1 is locked, but it is excluded because it is not available locally
+    ");
+}
+
 #[test]
 #[tracing_test::traced_test]
 fn test_unsat_no_candidates_for_child_1() {

--- a/tests/solver/snapshots/solver__root_constraints.snap
+++ b/tests/solver/snapshots/solver__root_constraints.snap
@@ -1,8 +1,9 @@
 ---
-source: tests/solver.rs
+source: tests/solver/main.rs
+assertion_line: 946
 expression: "solve_for_snapshot(provider, &requirements, &constraints)"
 ---
 The following packages are incompatible
 └─ union * can be installed with any of the following options:
    └─ union 1
-├─ the constraint union >=5, <6 cannot be fulfilled
+└─ the constraint union >=5, <6 cannot be fulfilled


### PR DESCRIPTION
A solvable that is locked and also excluded rules its package out entirely: the lock forbids every other candidate and the exclusion the locked one. The root-level conflict lines now carry the **exclusion reason** and are deduplicated by the locked solvable.

- Report `is locked, but it is excluded because <reason>` when the locked solvable is excluded
- Print one line per locked solvable instead of one per forbidden candidate
- The last root-level line now closes with `└─` instead of `├─` (visible in the `root_constraints` snapshot)

Found while working on conda/rattler#2609, where an excluded pin rendered like this:

```
└─ c * can be installed with any of the following options:
   └─ c 2 | 3 | 4
├─ c 1 is locked, but another version is required as reported above
├─ c 1 is locked, but another version is required as reported above
├─ c 1 is locked, but another version is required as reported above
```

and now renders like this:

```
└─ c * can be installed with any of the following options:
   └─ c 2 | 3 | 4
└─ c 1 is locked, but it is excluded because it is not available locally
```
