### PR TITLE
fix: release breaking multiversion support as 0.12.0

### DIFF
--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -27,6 +27,17 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
       - run: cargo rustdoc --all-features -- -D warnings -W unreachable-pub
 
+  semver-check:
+    name: SemVer check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+      - name: Install cargo-semver-checks
+        run: cargo install cargo-semver-checks --version 0.48.0 --locked
+      - name: Check public API compatibility
+        run: cargo semver-checks check-release --package resolvo
+
   format_and_lint:
     name: Format and Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -27,17 +27,6 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
       - run: cargo rustdoc --all-features -- -D warnings -W unreachable-pub
 
-  semver-check:
-    name: SemVer check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
-      - name: Install cargo-semver-checks
-        run: cargo install cargo-semver-checks --version 0.48.0 --locked
-      - name: Check public API compatibility
-        run: cargo semver-checks check-release --package resolvo
-
   format_and_lint:
     name: Format and Lint
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.11.2](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.11.1...resolvo-v0.11.2) - 2026-06-26
+## [0.12.0](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.11.1...resolvo-v0.12.0) - 2026-07-24
 
 ### Added
 
-- support multiversion packages ([#239](https://github.com/prefix-dev/resolvo/pull/239))
+- [**breaking**] support multiversion packages ([#239](https://github.com/prefix-dev/resolvo/pull/239))
 
 ### Fixed
 
 - update pixi lock file ([#249](https://github.com/prefix-dev/resolvo/pull/249))
+- report the exclusion reason for an excluded locked solvable ([#255](https://github.com/prefix-dev/resolvo/pull/255))
 
 ### Other
 
 - *(ci)* bump actions/checkout from 6.0.3 to 7.0.0 ([#248](https://github.com/prefix-dev/resolvo/pull/248))
 - *(ci)* bump MarcoIeni/release-plz-action from 0.5.129 to 0.5.130 ([#244](https://github.com/prefix-dev/resolvo/pull/244))
+- *(ci)* bump actions-rust-lang/setup-rust-toolchain ([#250](https://github.com/prefix-dev/resolvo/pull/250))
+- *(ci)* bump zgosalvez/github-actions-ensure-sha-pinned-actions ([#251](https://github.com/prefix-dev/resolvo/pull/251))
+- *(ci)* bump prefix-dev/setup-pixi from 0.9.6 to 0.10.0 ([#253](https://github.com/prefix-dev/resolvo/pull/253))
+- *(ci)* bump MarcoIeni/release-plz-action from 0.5.130 to 0.5.131 ([#254](https://github.com/prefix-dev/resolvo/pull/254))
 
 ## [0.11.1](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.11.0...resolvo-v0.11.1) - 2026-06-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resolvo"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "ahash",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cpp", "tools/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.11.2"
+version = "0.12.0"
 authors = [
     "Adolfo Ochagavía <github@adolfo.ochagavia.nl>",
     "Bas Zalmstra <zalmstra.bas@gmail.com>",


### PR DESCRIPTION
0.11.2 added `Candidates::allow_multiple`, which breaks downstream struct literals. Since that release was yanked, this carries the change in 0.12.0 instead. It also moves the 0.11.2 release notes and includes the merges since then (#250, #251, #253, #254, and #255).

release-plz runs its semver check after a change reaches `main`, so it cannot stop the merge that introduces an incompatible API. Its generated #247 PR nevertheless reported this change as API-compatible. Running cargo-semver-checks 0.48 directly against 0.11.1 and the 0.11.2 source reports `constructible_struct_adds_field` for `Candidates::allow_multiple`; the historical workflow logs are not available to determine why release-plz produced the incompatible result.

## Testing

- `cargo test --workspace --all-features -- --nocapture`
- `cargo +stable semver-checks check-release --package resolvo --baseline-version 0.11.1`
- `cargo fmt --check`
- `git diff --check`